### PR TITLE
Better sample for analysis if file is too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Better sample for analysis if file is too big and therefore reduce sample size [#143](https://github.com/datagouv/csv-detective/pull/143)
 
 ## 0.9.0 (2025-07-31)
 

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -197,5 +197,5 @@ def build_sample(table: pd.DataFrame) -> pd.DataFrame:
     )
     return pd.concat(
         [samples, table.sample(n=MAX_ROWS_ANALYSIS - len(samples), random_state=1)],
-        ignore_index=True
+        ignore_index=True,
     )

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -185,11 +185,13 @@ def build_sample(table: pd.DataFrame) -> pd.DataFrame:
             # one row with the minimum of the column
             table.loc[table[col] == table[col].dropna().min()].iloc[[0]]
             for col in table.columns
-        ] + [
+        ]
+        + [
             # one row with the maximum of the column
             table.loc[table[col] == table[col].dropna().max()].iloc[[0]]
             for col in table.columns
-        ] + [
+        ]
+        + [
             # one row with a NaN value if the column has any
             table.loc[table[col].isna()].iloc[[0]]
             for col in table.columns

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -14,6 +14,9 @@ from csv_detective.output.utils import prepare_output_dict
 from csv_detective.parsing.columns import MAX_ROWS_ANALYSIS, test_col, test_label
 from csv_detective.validate import validate
 
+# above this threshold, a columns is not considered categorical
+MAX_NUMBER_CATEGORICAL_VALUES = 25
+
 
 def detect_formats(
     table: pd.DataFrame,
@@ -28,14 +31,18 @@ def detect_formats(
     if on_sample:
         if verbose:
             logging.warning(f"File is too long, analysing the {MAX_ROWS_ANALYSIS} first rows")
-        table = table.sample(n=MAX_ROWS_ANALYSIS, random_state=1)
+        table = build_sample(table)
 
     if table.empty:
         res_categorical = []
         # res_continuous = []
     else:
         # Detects columns that are categorical
-        res_categorical, categorical_mask = detect_categorical_variable(table, verbose=verbose)
+        res_categorical, categorical_mask = detect_categorical_variable(
+            table,
+            max_number_categorical_values=MAX_NUMBER_CATEGORICAL_VALUES,
+            verbose=verbose,
+        )
         res_categorical = list(res_categorical)
         # Detect columns that are continuous (we already know the categorical) :
         # we don't need this for now, cuts processing time
@@ -166,3 +173,29 @@ def detect_formats(
             raise ValueError("Could not infer detected formats on the whole file")
 
     return analysis
+
+
+def build_sample(table: pd.DataFrame) -> pd.DataFrame:
+    """
+    building a sample of MAX_ROWS_ANALYSIS rows that contains at least one representative
+    of each possible value taken by columns that have at most MAX_NUMBER_CATEGORICAL_VALUES
+    different values
+    """
+    representatives = {
+        col: [value for value in table[col].unique() if not pd.isna(value)]
+        for col in table.columns
+        if table[col].nunique() <= MAX_NUMBER_CATEGORICAL_VALUES
+    }
+    # getting one row for each unique value
+    samples = pd.concat(
+        [
+            table.loc[table[col] == value].iloc[[0]]
+            for col in representatives.keys()
+            for value in representatives[col]
+        ],
+        ignore_index=True,
+    )
+    return pd.concat(
+        [samples, table.sample(n=MAX_ROWS_ANALYSIS - len(samples), random_state=1)],
+        ignore_index=True
+    )

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -14,7 +14,7 @@ from csv_detective.output.utils import prepare_output_dict
 from csv_detective.parsing.columns import MAX_ROWS_ANALYSIS, test_col, test_label
 from csv_detective.validate import validate
 
-# above this threshold, a columns is not considered categorical
+# above this threshold, a column is not considered categorical
 MAX_NUMBER_CATEGORICAL_VALUES = 25
 
 

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from csv_detective.utils import display_logs_depending_process_time
 
-MAX_ROWS_ANALYSIS = int(1e5)
+MAX_ROWS_ANALYSIS = int(1e4)
 
 
 def test_col_val(

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -280,7 +280,7 @@ def test_cast_json(mocked_responses, cast_json):
 
 def test_almost_uniform_column(mocked_responses):
     col_name = "int_not_bool"
-    expected_content = f"{col_name}\n" + "1\n" * int(1e6) + "9\n"
+    expected_content = f"{col_name}\n" + "9\n" + "1\n" * int(1e7)
     mocked_responses.get(
         "http://example.com/test.csv",
         body=expected_content,

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -276,3 +276,20 @@ def test_cast_json(mocked_responses, cast_json):
     )
     assert analysis["columns"]["a_simple_dict"]["python_type"] == "json"
     assert isinstance(df["a_simple_dict"][0], expected_type)
+
+
+def test_almost_uniform_column(mocked_responses):
+    col_name = "int_not_bool"
+    expected_content = f"{col_name}\n" + "1\n" * int(1e6) + "9\n"
+    mocked_responses.get(
+        "http://example.com/test.csv",
+        body=expected_content,
+        status=200,
+    )
+    analysis = routine(
+        file_path="http://example.com/test.csv",
+        num_rows=-1,
+        output_profile=False,
+        save_results=False,
+    )
+    assert analysis["columns"][col_name]["format"] == "int"


### PR DESCRIPTION
Fixes https://github.com/datagouv/csv-detective/issues/142
This fix allows us to safely scale down the sample size for analysis, to a size that can still be considered representative but in which we guarantee that most problematic values will appear, so that the analysis is faster