### PR TITLE
Remove `create_example_csv_file` from __init__ to avoid noise from `faker` in production logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove `create_example_csv_file` from __init__ to avoid noise from `faker` in production logs [#145](https://github.com/datagouv/csv-detective/pull/145)
 
 ## 0.9.0 (2025-07-31)
 

--- a/csv_detective/__init__.py
+++ b/csv_detective/__init__.py
@@ -1,2 +1,7 @@
-from csv_detective.explore_csv import routine, routine_minio, validate_then_detect  # noqa
-from csv_detective.output.example import create_example_csv_file  # noqa
+from csv_detective.explore_csv import routine, routine_minio, validate_then_detect
+
+__all__ = [
+    "routine",
+    "routine_minio",
+    "validate_then_detect",
+]


### PR DESCRIPTION
Having it in the `__init__` means importing it and calling `faker`, which is way too noisy in the logs:
```bash
Aug 20 14:47:10 server rq[3990273]: 2025-08-20 14:47:10 server faker.factory[3990273] DEBUG Looking for locale en_US in provider faker.providers.address.
Aug 20 14:47:10 server rq[3990273]: 2025-08-20 14:47:10 server faker.factory[3990273] DEBUG Provider faker.providers.address has been localized to en_US.
Aug 20 14:47:10 server rq[3990273]: 2025-08-20 14:47:10 server faker.factory[3990273] DEBUG Looking for locale en_US in provider faker.providers.automotive.
```
Maybe we should remove this function from `csv-detective` actually