### PR TITLE
Fix allowed valid proportions for geo float columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Better email detection [#151](https://github.com/datagouv/csv-detective/pull/151)
 - Sample can handle full NaN columns [#152](https://github.com/datagouv/csv-detective/pull/152)
 - Update .gitignore [#153](https://github.com/datagouv/csv-detective/pull/153)
+- Fix allowed valid proportions for geo float columns [#157](https://github.com/datagouv/csv-detective/pull/157)
 
 ## 0.9.2 (2025-08-26)
 

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -3,7 +3,7 @@ from frformat import LatitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 _latitudel93 = LatitudeL93()
 

--- a/csv_detective/detect_fields/FR/geo/latitude_wgs_fr_metropole/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_wgs_fr_metropole/__init__.py
@@ -1,6 +1,6 @@
 from csv_detective.detect_fields.other.float import _is as is_float
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -3,7 +3,7 @@ from frformat import LongitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 _longitudel93 = LongitudeL93()
 

--- a/csv_detective/detect_fields/FR/geo/longitude_wgs_fr_metropole/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_wgs_fr_metropole/__init__.py
@@ -1,6 +1,6 @@
 from csv_detective.detect_fields.other.float import _is as is_float
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 
 def _is(val):

--- a/csv_detective/detect_fields/geo/latitude_wgs/__init__.py
+++ b/csv_detective/detect_fields/geo/latitude_wgs/__init__.py
@@ -1,6 +1,6 @@
 from csv_detective.detect_fields.other.float import _is as is_float
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 
 def _is(val):

--- a/csv_detective/detect_fields/geo/longitude_wgs/__init__.py
+++ b/csv_detective/detect_fields/geo/longitude_wgs/__init__.py
@@ -1,6 +1,6 @@
 from csv_detective.detect_fields.other.float import _is as is_float
 
-PROPORTION = 0.9
+PROPORTION = 1
 
 
 def _is(val):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -79,6 +79,7 @@ from csv_detective.detection.variables import (
 from csv_detective.load_tests import return_all_tests
 from csv_detective.output.dataframe import cast
 from csv_detective.output.utils import prepare_output_dict
+from csv_detective.parsing.columns import test_col
 
 
 def test_all_tests_return_bool():
@@ -461,3 +462,27 @@ def test_early_detection(args):
         res = module._is(value)
         assert res
         mock_func.assert_not_called()
+
+
+def test_all_proportion_1():
+    all_tests = return_all_tests("ALL", "detect_fields")
+    prop_1 = {
+        t.__name__.split(".")[-1]: eval(
+            t.__name__.split(".")[-1]
+            if t.__name__.split(".")[-1] not in ["int", "float"]
+            else "test_" + t.__name__.split(".")[-1]
+        )
+        for t in all_tests
+        if t.PROPORTION == 1
+    }
+    # building a table that uses only correct values for these formats, except on one row
+    table = pd.DataFrame(
+        {
+            test_name: (fields[test_module][True] * 100)[:100] + ["not_suitable"]
+            for test_name, test_module in prop_1.items()
+        }
+    )
+    # testing columns for all formats
+    returned_table = test_col(table, all_tests, limited_output=True)
+    # the analysis should have found no match on any format
+    assert all(returned_table[col].sum() == 0 for col in table.columns)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -79,7 +79,7 @@ from csv_detective.detection.variables import (
 from csv_detective.load_tests import return_all_tests
 from csv_detective.output.dataframe import cast
 from csv_detective.output.utils import prepare_output_dict
-from csv_detective.parsing.columns import test_col
+from csv_detective.parsing.columns import test_col as col_test  # to prevent pytest from testing it
 
 
 def test_all_tests_return_bool():
@@ -483,6 +483,6 @@ def test_all_proportion_1():
         }
     )
     # testing columns for all formats
-    returned_table = test_col(table, all_tests, limited_output=True)
+    returned_table = col_test(table, all_tests, limited_output=True)
     # the analysis should have found no match on any format
     assert all(returned_table[col].sum() == 0 for col in table.columns)


### PR DESCRIPTION
Fixes [this kind of issue](https://errors.data.gouv.fr/organizations/sentry/issues/265555/?environment=demo&project=21&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=14&utc=true) where a column was considered a certain type while it wasn't, because PROPORTION was not set to 1