### PR TITLE
Chunks everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update .gitignore [#153](https://github.com/datagouv/csv-detective/pull/153)
 - Fix allowed valid proportions for geo float columns [#157](https://github.com/datagouv/csv-detective/pull/157)
 - Remove Minio-related parts of the code [#158](https://github.com/datagouv/csv-detective/pull/158)
+- Process big csv files in chunks (/!\ breaking changes) [#159](https://github.com/datagouv/csv-detective/pull/159)
 
 ## 0.9.2 (2025-08-26)
 

--- a/csv_detective/__init__.py
+++ b/csv_detective/__init__.py
@@ -1,6 +1,7 @@
-from csv_detective.explore_csv import routine, validate_then_detect
+from csv_detective.explore_csv import routine, validate, validate_then_detect
 
 __all__ = [
     "routine",
+    "validate",
     "validate_then_detect",
 ]

--- a/csv_detective/detection/engine.py
+++ b/csv_detective/detection/engine.py
@@ -30,9 +30,7 @@ def detect_engine(file_path: str, verbose=False) -> Optional[str]:
     }
     # if none of the above, we move forwards with the csv process
     if is_url(file_path):
-        remote_content = next(
-            requests.get(file_path, stream=True).iter_content(chunk_size=1024)
-        )
+        remote_content = next(requests.get(file_path, stream=True).iter_content(chunk_size=1024))
         engine = mapping.get(magic.from_buffer(remote_content, mime=True))
     else:
         engine = mapping.get(magic.from_file(file_path, mime=True))

--- a/csv_detective/detection/engine.py
+++ b/csv_detective/detection/engine.py
@@ -30,7 +30,9 @@ def detect_engine(file_path: str, verbose=False) -> Optional[str]:
     }
     # if none of the above, we move forwards with the csv process
     if is_url(file_path):
-        remote_content = requests.get(file_path).content
+        remote_content = next(
+            requests.get(file_path, stream=True).iter_content(chunk_size=1024)
+        )
         engine = mapping.get(magic.from_buffer(remote_content, mime=True))
     else:
         engine = mapping.get(magic.from_file(file_path, mime=True))

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -27,7 +27,7 @@ def detect_formats(
     skipna: bool = True,
     verbose: bool = False,
 ) -> tuple[dict, Optional[dict[str, pd.Series]]]:
-    on_sample = analysis.get("total_lines") is None
+    in_chunks = analysis.get("total_lines") is None
 
     # list testing to be performed
     all_tests_fields = return_all_tests(
@@ -42,7 +42,7 @@ def detect_formats(
         return analysis, None
 
     # Perform testing on fields
-    if not on_sample:
+    if not in_chunks:
         # table is small enough to be tested in one go
         scores_table_fields = test_col(
             table=table,

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -71,7 +71,9 @@ def detect_formats(
     analysis["columns_fields"] = prepare_output_dict(scores_table_fields, limited_output)
 
     # Perform testing on labels
-    scores_table_labels = test_label(analysis["header"], all_tests_labels, limited_output, verbose=verbose)
+    scores_table_labels = test_label(
+        analysis["header"], all_tests_labels, limited_output, verbose=verbose
+    )
     analysis["columns_labels"] = prepare_output_dict(scores_table_labels, limited_output)
 
     # Multiply the results of the fields by 1 + 0.5 * the results of the labels.

--- a/csv_detective/detection/variables.py
+++ b/csv_detective/detection/variables.py
@@ -56,7 +56,7 @@ def detect_categorical_variable(
     threshold_pct_categorical: float = 0.05,
     max_number_categorical_values: int = 25,
     verbose: bool = False,
-):
+) -> tuple[list[str], pd.DataFrame]:
     """
     Heuristically detects whether a table (df) contains categorical values according to
     the number of unique values contained.
@@ -94,4 +94,4 @@ def detect_categorical_variable(
             f"Detected {sum(res)} categorical columns out of {len(table.columns)} in {round(time() - start, 3)}s",
             time() - start,
         )
-    return res.index[res], res
+    return list(res.index[res]), res

--- a/csv_detective/explore_csv.py
+++ b/csv_detective/explore_csv.py
@@ -123,7 +123,7 @@ def validate_then_detect(
         if is_url(file_path):
             logging.info("Path recognized as a URL")
 
-    is_valid, table, analysis = validate(
+    is_valid, table, analysis, col_values = validate(
         file_path=file_path,
         previous_analysis=previous_analysis,
         encoding=previous_analysis.get("encoding"),
@@ -140,7 +140,7 @@ def validate_then_detect(
             verbose=verbose,
         )
     if not is_valid:
-        analysis = detect_formats(
+        analysis, col_values = detect_formats(
             table=table,
             analysis=analysis,
             file_path=file_path,
@@ -163,6 +163,7 @@ def validate_then_detect(
             cast_json=cast_json,
             verbose=verbose,
             sheet_name=analysis.get("sheet_name"),
+            _col_values=col_values,
         )
     finally:
         if verbose:

--- a/csv_detective/explore_csv.py
+++ b/csv_detective/explore_csv.py
@@ -126,9 +126,6 @@ def validate_then_detect(
     is_valid, table, analysis, col_values = validate(
         file_path=file_path,
         previous_analysis=previous_analysis,
-        encoding=previous_analysis.get("encoding"),
-        sep=previous_analysis.get("separator"),
-        sheet_name=previous_analysis.get("sheet_name"),
         verbose=verbose,
         skipna=skipna,
     )

--- a/csv_detective/explore_csv.py
+++ b/csv_detective/explore_csv.py
@@ -125,7 +125,6 @@ def validate_then_detect(
     is_valid, table, analysis = validate(
         file_path=file_path,
         previous_analysis=previous_analysis,
-        num_rows=num_rows,
         encoding=previous_analysis.get("encoding"),
         sep=previous_analysis.get("separator"),
         sheet_name=previous_analysis.get("sheet_name"),

--- a/csv_detective/explore_csv.py
+++ b/csv_detective/explore_csv.py
@@ -71,7 +71,7 @@ def routine(
         sheet_name=sheet_name,
     )
 
-    analysis = detect_formats(
+    analysis, _col_values = detect_formats(
         table=table,
         analysis=analysis,
         file_path=file_path,
@@ -95,6 +95,7 @@ def routine(
             cast_json=cast_json,
             verbose=verbose,
             sheet_name=sheet_name,
+            _col_values=_col_values,
         )
     finally:
         if verbose:

--- a/csv_detective/load_tests.py
+++ b/csv_detective/load_tests.py
@@ -20,7 +20,7 @@ def get_all_packages(detect_type) -> list:
 def return_all_tests(
     user_input_tests: Union[str, list],
     detect_type: str,
-) -> list:
+) -> dict[str, dict]:
     """
     returns all tests that have a method _is and are listed in the user_input_tests
     the function can select a sub_package from csv_detective
@@ -41,6 +41,7 @@ def return_all_tests(
     else:
         tests_to_do = [f"{detect_type}.{x}" for x in user_input_tests if x[0] != "-"]
     tests_skipped = [f"{detect_type}.{x[1:]}" for x in user_input_tests if x[0] == "-"]
+    # removing specified (groups of) tests
     all_tests = [
         # this is why we need to import detect_fields/labels
         eval(x)
@@ -48,6 +49,11 @@ def return_all_tests(
         if any([y == x[: len(y)] for y in tests_to_do])
         and all([y != x[: len(y)] for y in tests_skipped])
     ]
-    # to remove groups of tests
-    all_tests = [test for test in all_tests if "_is" in dir(test)]
-    return all_tests
+    return {
+        test.__name__.split(".")[-1]: {
+            "func": test._is,
+            "prop": test.PROPORTION,
+            "module": test,
+        }
+        for test in all_tests if "_is" in dir(test)
+    }

--- a/csv_detective/load_tests.py
+++ b/csv_detective/load_tests.py
@@ -55,5 +55,6 @@ def return_all_tests(
             "prop": test.PROPORTION,
             "module": test,
         }
-        for test in all_tests if "_is" in dir(test)
+        for test in all_tests
+        if "_is" in dir(test)
     }

--- a/csv_detective/output/__init__.py
+++ b/csv_detective/output/__init__.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Optional, Union
+from typing import Iterator, Optional, Union
 
 import pandas as pd
 
@@ -25,7 +25,7 @@ def generate_output(
     verbose: bool = False,
     sheet_name: Optional[Union[str, int]] = None,
     _col_values: Optional[dict[str, pd.Series]] = None,
-) -> Union[dict, tuple[dict, pd.DataFrame]]:
+) -> Union[dict, tuple[dict, Iterator[pd.DataFrame]]]:
     if output_profile:
         analysis["profile"] = create_profile(
             table=table,

--- a/csv_detective/output/__init__.py
+++ b/csv_detective/output/__init__.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from csv_detective.utils import is_url
 
-from .dataframe import cast_df
+from .dataframe import cast_df_chunks
 from .profile import create_profile
 from .schema import generate_table_schema
 
@@ -56,9 +56,10 @@ def generate_output(
         analysis["schema"] = generate_table_schema(analysis, save_results=False, verbose=verbose)
 
     if output_df:
-        return analysis, cast_df(
+        return analysis, cast_df_chunks(
             df=table,
-            columns=analysis["columns"],
+            analysis=analysis,
+            file_path=file_path,
             cast_json=cast_json,
             verbose=verbose,
         )

--- a/csv_detective/output/__init__.py
+++ b/csv_detective/output/__init__.py
@@ -24,6 +24,7 @@ def generate_output(
     cast_json: bool = True,
     verbose: bool = False,
     sheet_name: Optional[Union[str, int]] = None,
+    _col_values: Optional[dict[str, pd.Series]] = None,
 ) -> Union[dict, tuple[dict, pd.DataFrame]]:
     if output_profile:
         analysis["profile"] = create_profile(
@@ -33,6 +34,7 @@ def generate_output(
             limited_output=limited_output,
             cast_json=cast_json,
             verbose=verbose,
+            _col_values=_col_values,
         )
 
     if save_results:

--- a/csv_detective/output/example.py
+++ b/csv_detective/output/example.py
@@ -10,6 +10,8 @@ import requests
 import rstr
 from faker import Faker
 
+from csv_detective.utils import is_url
+
 fake = Faker()
 
 
@@ -183,7 +185,7 @@ def create_example_csv_file(
     }
 
     if schema_path:
-        if schema_path.startswith("http"):
+        if is_url(schema_path):
             schema = requests.get(schema_path).json()
         else:
             with open(schema_path, encoding=encoding) as jsonfile:

--- a/csv_detective/output/profile.py
+++ b/csv_detective/output/profile.py
@@ -105,7 +105,11 @@ def create_profile(
             nb_missing_values=(
                 len(table[c].loc[table[c].isna()])
                 if _col_values is None
-                else _col_values.loc[pd.NA]
+                else (
+                    _col_values[c].loc[pd.NA]
+                    if pd.NA in _col_values[c].index
+                    else 0
+                )
             ),
         )
     if verbose:

--- a/csv_detective/output/profile.py
+++ b/csv_detective/output/profile.py
@@ -55,7 +55,9 @@ def create_profile(
                 cast_col[c] = (
                     cast_col[c].astype(pd.Int64Dtype())
                     if columns[c]["python_type"] == "int"
-                    else cast_col[c].apply(lambda x: float_casting(x) if isinstance(x, str) else pd.NA)
+                    else cast_col[c].apply(
+                        lambda x: float_casting(x) if isinstance(x, str) else pd.NA
+                    )
                 )
                 stats = {
                     "min": cast_prevent_nan(cast_col[c].min(), columns[c]["python_type"]),
@@ -76,11 +78,8 @@ def create_profile(
             del cast_col
         # for all formats we want most frequent values, nb unique values and nb missing values
         tops_bruts = (
-            (
-                table[c].value_counts()
-                if _col_values is None
-                else _col_values[c].sort_values()
-            ).reset_index()
+            (table[c].value_counts() if _col_values is None else _col_values[c].sort_values())
+            .reset_index()
             .iloc[:10]
             .to_dict(orient="records")
         )
@@ -105,11 +104,7 @@ def create_profile(
             nb_missing_values=(
                 len(table[c].loc[table[c].isna()])
                 if _col_values is None
-                else (
-                    _col_values[c].loc[pd.NA]
-                    if pd.NA in _col_values[c].index
-                    else 0
-                )
+                else (_col_values[c].loc[pd.NA] if pd.NA in _col_values[c].index else 0)
             ),
         )
     if verbose:

--- a/csv_detective/output/profile.py
+++ b/csv_detective/output/profile.py
@@ -1,7 +1,9 @@
 import logging
 from collections import defaultdict
 from time import time
+from typing import Optional
 
+import numpy as np
 import pandas as pd
 
 from csv_detective.detect_fields.other.float import float_casting
@@ -15,6 +17,7 @@ def create_profile(
     limited_output: bool = True,
     cast_json: bool = True,
     verbose: bool = False,
+    _col_values: Optional[dict[str, pd.Series]] = None,
 ) -> dict:
     if verbose:
         start = time()
@@ -31,24 +34,53 @@ def create_profile(
     for c in table.columns:
         # for numerical formats we want min, max, mean, std
         if columns[c]["python_type"] in ["float", "int"]:
-            # we locally cast the column to perform the operations, using the same method as in cast_df
-            cast_col = (
-                table[c].astype(pd.Int64Dtype())
-                if columns[c]["python_type"] == "int"
-                else table[c].apply(lambda x: float_casting(x) if isinstance(x, str) else pd.NA)
-            )
-            profile[c].update(
-                min=cast_prevent_nan(cast_col.min(), columns[c]["python_type"]),
-                max=cast_prevent_nan(cast_col.max(), columns[c]["python_type"]),
-                mean=cast_prevent_nan(cast_col.mean(), columns[c]["python_type"]),
-                std=cast_prevent_nan(cast_col.std(), columns[c]["python_type"]),
-            )
+            # if we have read the file in chunks we already have what we need
+            if _col_values is None:
+                # we locally cast the column to perform the operations,
+                # using the same method as in cast_df
+                cast_col = (
+                    table[c].astype(pd.Int64Dtype())
+                    if columns[c]["python_type"] == "int"
+                    else table[c].apply(lambda x: float_casting(x) if isinstance(x, str) else pd.NA)
+                )
+                stats = {
+                    "min": cast_prevent_nan(cast_col.min(), columns[c]["python_type"]),
+                    "mean": cast_prevent_nan(cast_col.mean(), columns[c]["python_type"]),
+                    "max": cast_prevent_nan(cast_col.max(), columns[c]["python_type"]),
+                    "std": cast_prevent_nan(cast_col.std(), columns[c]["python_type"]),
+                }
+            else:
+                cast_col = _col_values[c].reset_index()
+                cast_col = cast_col.loc[cast_col[c].notna()]
+                cast_col[c] = (
+                    cast_col[c].astype(pd.Int64Dtype())
+                    if columns[c]["python_type"] == "int"
+                    else cast_col[c].apply(lambda x: float_casting(x) if isinstance(x, str) else pd.NA)
+                )
+                stats = {
+                    "min": cast_prevent_nan(cast_col[c].min(), columns[c]["python_type"]),
+                    "mean": cast_prevent_nan(
+                        (cast_col[c] * cast_col["count"]).sum() / sum(cast_col["count"]),
+                        columns[c]["python_type"],
+                    ),
+                    "max": cast_prevent_nan(cast_col[c].max(), columns[c]["python_type"]),
+                }
+                stats["std"] = cast_prevent_nan(
+                    np.sqrt(
+                        sum(cast_col["count"] * (cast_col[c] - stats["mean"]) ** 2)
+                        / sum(cast_col["count"])
+                    ),
+                    columns[c]["python_type"],
+                )
+            profile[c].update(**stats)
             del cast_col
         # for all formats we want most frequent values, nb unique values and nb missing values
         tops_bruts = (
-            table.loc[table[c].notna(), c]
-            .value_counts()
-            .reset_index()
+            (
+                table[c].value_counts()
+                if _col_values is None
+                else _col_values[c].sort_values()
+            ).reset_index()
             .iloc[:10]
             .to_dict(orient="records")
         )
@@ -61,16 +93,25 @@ def create_profile(
                 for tb in tops_bruts
             ],
             nb_distinct=(
-                table[c].nunique()
-                if columns[c]["python_type"] != "json" or not cast_json
-                # a column containing cast json is not serializable
-                else table[c].astype(str).nunique()
+                (
+                    table[c].nunique()
+                    if columns[c]["python_type"] != "json" or not cast_json
+                    # a column containing cast json is not serializable
+                    else table[c].astype(str).nunique()
+                )
+                if _col_values is None
+                else len(_col_values)
             ),
-            nb_missing_values=len(table[c].loc[table[c].isna()]),
+            nb_missing_values=(
+                len(table[c].loc[table[c].isna()])
+                if _col_values is None
+                else _col_values.loc[pd.NA]
+            ),
         )
     if verbose:
         display_logs_depending_process_time(
             f"Created profile in {round(time() - start, 3)}s",
             time() - start,
         )
+    del _col_values
     return profile

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -2,8 +2,8 @@ import logging
 from time import time
 from typing import Callable
 
-from more_itertools import peekable
 import pandas as pd
+from more_itertools import peekable
 
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import display_logs_depending_process_time
@@ -117,7 +117,9 @@ def test_col(
     return return_table
 
 
-def test_label(columns: list[str], all_tests: dict[str, dict], limited_output: bool, verbose: bool = False):
+def test_label(
+    columns: list[str], all_tests: dict[str, dict], limited_output: bool, verbose: bool = False
+):
     if verbose:
         start = time()
         logging.info("Testing labels to get types")
@@ -153,9 +155,7 @@ def test_col_chunks(
 ) -> tuple[pd.DataFrame, dict, dict[str, pd.Series]]:
     def build_remaining_tests_per_col(return_table: pd.DataFrame) -> dict[str, list[str]]:
         return {
-            col: [
-                test for test in return_table.index if return_table.loc[test, col] > 0
-            ]
+            col: [test for test in return_table.index if return_table.loc[test, col] > 0]
             for col in return_table.columns
         }
 
@@ -170,10 +170,7 @@ def test_col_chunks(
     # hashing rows to get nb_duplicates
     row_hashes_count = table.apply(lambda row: hash(tuple(row)), axis=1).value_counts()
     # getting values for profile to read the file only once
-    col_values = {
-        col: table[col].value_counts(dropna=False)
-        for col in table.columns
-    }
+    col_values = {col: table[col].value_counts(dropna=False) for col in table.columns}
 
     # only csv files can end up here, can't chunk excel
     chunks = pd.read_csv(
@@ -233,19 +230,16 @@ def test_col_chunks(
                 )
                 return_table.loc[test, col] = (
                     # if this batch's column tested 0 then test fails overall
-                    0 if batch_col_test == 0
+                    0
+                    if batch_col_test == 0
                     # otherwise updating the score with weighted average
-                    else (
-                        (return_table.loc[test, col] * idx + batch_col_test)
-                        / (idx + 1)
-                    )
+                    else ((return_table.loc[test, col] * idx + batch_col_test) / (idx + 1))
                 )
         remaining_tests_per_col = build_remaining_tests_per_col(return_table)
         batch, batch_number = [], batch_number + 1
     analysis["nb_duplicates"] = sum(row_hashes_count > 1)
     analysis["categorical"] = [
-        col for col, values in col_values.items()
-        if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES
+        col for col, values in col_values.items() if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES
     ]
     # handling that empty columns score 1 everywhere
     for col in return_table.columns:

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -180,6 +180,7 @@ def test_col_chunks(
         dtype=str,
         encoding=analysis["encoding"],
         sep=analysis["separator"],
+        skiprows=analysis["header_row_idx"],
         compression=analysis.get("compression"),
         chunksize=CHUNK_SIZE,
     )

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -125,22 +125,25 @@ def test_col(
     return return_table
 
 
-def test_label(table: pd.DataFrame, all_tests: list, limited_output: bool, verbose: bool = False):
+def test_label(columns: list[str], all_tests: list, limited_output: bool, verbose: bool = False):
     if verbose:
         start = time()
         logging.info("Testing labels to get types")
-    test_funcs = dict()
-    for test in all_tests:
-        name = test.__name__.split(".")[-1]
-        test_funcs[name] = {"func": test._is, "prop": test.PROPORTION}
+    test_funcs = {
+        test.__name__.split(".")[-1]: {
+            "func": test._is,
+            "prop": test.PROPORTION,
+        }
+        for test in all_tests
+    }
 
-    return_table = pd.DataFrame(columns=table.columns)
+    return_table = pd.DataFrame(columns=columns)
     for idx, (key, value) in enumerate(test_funcs.items()):
         if verbose:
             start_type = time()
         return_table.loc[key] = [
             test_col_label(col_name, value["func"], value["prop"], limited_output=limited_output)
-            for col_name in table.columns
+            for col_name in columns
         ]
         if verbose:
             display_logs_depending_process_time(

--- a/csv_detective/parsing/csv.py
+++ b/csv_detective/parsing/csv.py
@@ -38,7 +38,7 @@ def parse_csv(
         # branch between small and big files starts here
         if total_lines == CHUNK_SIZE:
             if verbose:
-                logging.warning(f"File is too long, analysing a sample of {CHUNK_SIZE} rows")
+                logging.warning(f"File is too long, analysing in chunks of {CHUNK_SIZE} rows")
             total_lines, nb_duplicates = None, None
         else:
             nb_duplicates = len(table.loc[table.duplicated()])

--- a/csv_detective/parsing/load.py
+++ b/csv_detective/parsing/load.py
@@ -69,7 +69,14 @@ def load_file(
             binary_file.seek(0)
         # decoding and reading file
         if is_url(file_path) or engine in COMPRESSION_ENGINES:
-            str_file = StringIO(binary_file.read().decode(encoding=encoding))
+            str_file = StringIO()
+            while True:
+                chunk = binary_file.read(1024**2)
+                if not chunk:
+                    break
+                str_file.write(chunk.decode(encoding=encoding))
+            del binary_file
+            str_file.seek(0)
         else:
             str_file = open(file_path, "r", encoding=encoding)
         if sep is None:
@@ -82,6 +89,7 @@ def load_file(
         table, total_lines, nb_duplicates = parse_csv(
             str_file, encoding, sep, num_rows, header_row_idx, verbose=verbose
         )
+        del str_file
         if table.empty:
             raise ValueError("Table seems to be empty")
         analysis = {

--- a/csv_detective/parsing/load.py
+++ b/csv_detective/parsing/load.py
@@ -45,6 +45,8 @@ def load_file(
             sheet_name=sheet_name,
             verbose=verbose,
         )
+        if table.empty:
+            raise ValueError("Table seems to be empty")
         header = table.columns.to_list()
         analysis = {
             "engine": engine,
@@ -73,28 +75,31 @@ def load_file(
         if sep is None:
             sep = detect_separator(str_file, verbose=verbose)
         header_row_idx, header = detect_headers(str_file, sep, verbose=verbose)
-        if header is None:
-            return {"error": True}
-        elif isinstance(header, list):
-            if any([x is None for x in header]):
-                return {"error": True}
+        if header is None or (isinstance(header, list) and any([h is None for h in header])):
+            raise ValueError("Could not retrieve headers")
         heading_columns = detect_heading_columns(str_file, sep, verbose=verbose)
         trailing_columns = detect_trailing_columns(str_file, sep, heading_columns, verbose=verbose)
         table, total_lines, nb_duplicates = parse_csv(
             str_file, encoding, sep, num_rows, header_row_idx, verbose=verbose
         )
+        if table.empty:
+            raise ValueError("Table seems to be empty")
         analysis = {
             "encoding": encoding,
             "separator": sep,
             "heading_columns": heading_columns,
             "trailing_columns": trailing_columns,
         }
+        if engine is not None:
+            analysis["compression"] = engine
     analysis.update(
         {
             "header_row_idx": header_row_idx,
             "header": header,
-            "total_lines": total_lines,
-            "nb_duplicates": nb_duplicates,
         }
     )
+    if total_lines is not None:
+        analysis["total_lines"] = total_lines
+    if nb_duplicates is not None:
+        analysis["nb_duplicates"] = nb_duplicates
     return table, analysis

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 from csv_detective.load_tests import return_all_tests
 from csv_detective.parsing.columns import MAX_NUMBER_CATEGORICAL_VALUES, test_col_val
-from csv_detective.parsing.csv import CHUNK_SIZE
 
+VALIDATION_CHUNK_SIZE = int(1e5)
 logging.basicConfig(level=logging.INFO)
 
 tests = return_all_tests("ALL", "detect_fields")
@@ -31,7 +31,7 @@ def validate(
                 encoding=previous_analysis["encoding"],
                 skiprows=previous_analysis["header_row_idx"],
                 compression=previous_analysis.get("compression"),
-                chunksize=CHUNK_SIZE,
+                chunksize=VALIDATION_CHUNK_SIZE,
             )
             analysis = {
                 k: v for k, v in previous_analysis.items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "frformat==0.4.0",
     "Faker>=33.0.0",
     "rstr==3.2.2",
+    "more-itertools>=10.8.0",
 ]
 requires-python = ">=3.9,<3.14"
 license = { text = "MIT" }

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -467,11 +467,7 @@ def test_early_detection(args):
 def test_all_proportion_1():
     all_tests = return_all_tests("ALL", "detect_fields")
     prop_1 = {
-        name: eval(
-            name
-            if name not in ["int", "float"]
-            else "test_" + name
-        )
+        name: eval(name if name not in ["int", "float"] else "test_" + name)
         for name, attr in all_tests.items()
         if attr["prop"] == 1
     }

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -84,13 +84,13 @@ from csv_detective.parsing.columns import test_col as col_test  # to prevent pyt
 
 def test_all_tests_return_bool():
     all_tests = return_all_tests("ALL", "detect_fields")
-    for test in all_tests:
+    for attr in all_tests.values():
         for tmp in ["a", "9", "3.14", "[]", float("nan"), "2021-06-22 10:20:10"]:
-            assert isinstance(test._is(tmp), bool)
+            assert isinstance(attr["func"](tmp), bool)
 
 
 # categorical
-def test_detetect_categorical_variable():
+def test_detect_categorical_variable():
     categorical_col = ["type_a"] * 33 + ["type_b"] * 33 + ["type_c"] * 34
     categorical_col2 = [str(k // 20) for k in range(100)]
     not_categorical_col = [i for i in range(100)]
@@ -103,7 +103,7 @@ def test_detetect_categorical_variable():
     df = pd.DataFrame(df_dict, dtype=str)
 
     res, _ = detect_categorical_variable(df)
-    assert len(res.values) and all(k in res.values for k in ["cat", "cat2"])
+    assert len(res) and all(k in res for k in ["cat", "cat2"])
 
 
 # continuous
@@ -386,8 +386,8 @@ fields = {
 
 def test_all_fields_have_tests():
     all_tests = return_all_tests("ALL", "detect_fields")
-    for test in all_tests:
-        assert fields.get(test)
+    for attr in all_tests.values():
+        assert fields.get(attr["module"])
 
 
 @pytest.mark.parametrize(
@@ -467,13 +467,13 @@ def test_early_detection(args):
 def test_all_proportion_1():
     all_tests = return_all_tests("ALL", "detect_fields")
     prop_1 = {
-        t.__name__.split(".")[-1]: eval(
-            t.__name__.split(".")[-1]
-            if t.__name__.split(".")[-1] not in ["int", "float"]
-            else "test_" + t.__name__.split(".")[-1]
+        name: eval(
+            name
+            if name not in ["int", "float"]
+            else "test_" + name
         )
-        for t in all_tests
-        if t.PROPORTION == 1
+        for name, attr in all_tests.items()
+        if attr["prop"] == 1
     }
     # building a table that uses only correct values for these formats, except on one row
     table = pd.DataFrame(

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -6,15 +6,19 @@ import responses
 
 from csv_detective import routine
 from csv_detective.output.profile import create_profile
-from csv_detective.parsing.columns import MAX_ROWS_ANALYSIS
+from csv_detective.parsing.csv import CHUNK_SIZE
 
 
 @pytest.mark.parametrize(
-    "max_rows_analysis",
-    (100, int(1e5)),
+    "chunk_size",
+    (100, 404, int(1e5)),
 )
-def test_columns_output_on_file(max_rows_analysis):
-    with patch("csv_detective.detection.formats.MAX_ROWS_ANALYSIS", max_rows_analysis):
+def test_columns_output_on_file(chunk_size):
+    with (
+        # maybe we should refactor later to avoid having to patch everywhere
+        patch("csv_detective.parsing.csv.CHUNK_SIZE", chunk_size),
+        patch("csv_detective.parsing.columns.CHUNK_SIZE", chunk_size),
+    ):
         output = routine(
             file_path="tests/data/a_test_file.csv",
             num_rows=-1,
@@ -248,17 +252,23 @@ def mocked_responses():
 def test_urls(mocked_responses, params):
     file_name, checks = params
     url = f"http://example.com/{file_name}"
+    expected_content = open(f"tests/data/{file_name}", "rb").read()
     mocked_responses.get(
         url,
-        body=open(f"tests/data/{file_name}", "rb").read(),
+        body=expected_content,
         status=200,
     )
-    _ = routine(
-        file_path=url,
-        num_rows=-1,
-        output_profile=False,
-        save_results=False,
-    )
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = expected_content
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        _ = routine(
+            file_path=url,
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
     for k, v in checks.items():
         if v is None:
             assert not _.get(k)
@@ -289,13 +299,14 @@ def test_nan_values(expected_type):
 
 
 def test_output_df():
-    output, df = routine(
+    output, df_chunks = routine(
         file_path="tests/data/b_test_file.csv",
         num_rows=-1,
         output_profile=False,
         save_results=False,
         output_df=True,
     )
+    df = pd.concat(df_chunks, ignore_index=True)
     assert isinstance(output, dict)
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 6
@@ -317,14 +328,20 @@ def test_cast_json(mocked_responses, cast_json):
         body=expected_content,
         status=200,
     )
-    analysis, df = routine(
-        file_path="http://example.com/test.csv",
-        num_rows=-1,
-        output_profile=False,
-        save_results=False,
-        output_df=True,
-        cast_json=cast_json,
-    )
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = expected_content.encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        analysis, df_chunks = routine(
+            file_path="http://example.com/test.csv",
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+            output_df=True,
+            cast_json=cast_json,
+        )
+    df = pd.concat(df_chunks, ignore_index=True)
     assert analysis["columns"]["a_simple_dict"]["python_type"] == "json"
     assert isinstance(df["a_simple_dict"][0], expected_type)
 
@@ -337,27 +354,38 @@ def test_almost_uniform_column(mocked_responses):
         body=expected_content,
         status=200,
     )
-    analysis = routine(
-        file_path="http://example.com/test.csv",
-        num_rows=-1,
-        output_profile=False,
-        save_results=False,
-    )
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = expected_content.encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        analysis = routine(
+            file_path="http://example.com/test.csv",
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
     assert analysis["columns"][col_name]["format"] == "int"
 
 
 def test_full_nan_column(mocked_responses):
     # we want a file that needs sampling
-    expected_content = "only_nan,second_col\n" + ",1\n" * (MAX_ROWS_ANALYSIS + 1)
+    expected_content = "only_nan,second_col\n" + ",1\n" * (CHUNK_SIZE + 1)
     mocked_responses.get(
         "http://example.com/test.csv",
         body=expected_content,
         status=200,
     )
-    # just testing it doesn't fail
-    routine(
-        file_path="http://example.com/test.csv",
-        num_rows=-1,
-        output_profile=False,
-        save_results=False,
-    )
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        # Create a mock HTTP response object
+        mock_response = MagicMock()
+        mock_response.read.return_value = expected_content.encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        # just testing it doesn't fail
+        routine(
+            file_path="http://example.com/test.csv",
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -34,5 +34,8 @@ def tests_conformity():
 
 
 def test_all_tests_have_unique_name():
-    names = [t.__name__.split(".")[-1] for t in return_all_tests("ALL", "detect_fields")]
+    names = [
+        attr["module"].__name__.split(".")[-1]
+        for attr in return_all_tests("ALL", "detect_fields").values()
+    ]
     assert len(names) == len(set(names))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -49,12 +49,9 @@ def test_validation(_params):
     for dotkey in modif_previous_analysis:
         keys = dotkey.split(".")
         set_nested_value(previous_analysis, keys, modif_previous_analysis[dotkey])
-    is_valid, table, analysis = validate(
+    is_valid, table, analysis, col_values = validate(
         "tests/data/a_test_file.csv",
         previous_analysis=previous_analysis,
-        num_rows=-1,
-        sep=previous_analysis.get("separator"),
-        encoding=previous_analysis.get("encoding"),
     )
     assert is_valid == should_be_valid
     if table_type is None:
@@ -65,6 +62,15 @@ def test_validation(_params):
         assert analysis is None
     else:
         assert isinstance(analysis, analysis_type)
+    if should_be_valid:
+        assert isinstance(col_values, dict)
+        assert all(
+            col in table.columns
+            and isinstance(values, pd.Series)
+            for col, values in col_values.items()
+        )
+    else:
+        assert col_values is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -65,8 +65,7 @@ def test_validation(_params):
     if should_be_valid:
         assert isinstance(col_values, dict)
         assert all(
-            col in table.columns
-            and isinstance(values, pd.Series)
+            col in table.columns and isinstance(values, pd.Series)
             for col, values in col_values.items()
         )
     else:


### PR DESCRIPTION
Big csv files are processed in chunks (excel files are not chunkable) and the cast dataframe is also returned as an iterator of cast chunks (which is a breaking change)
This fixes a couple of things:
- not crashing anymore if the analysis on the first X rows fails on the rest of the file
- enables the analysis of big (**big**) files, because we are never loading the whole file in memory, for instance [the whole DVF file](https://www.data.gouv.fr/datasets/demandes-de-valeurs-foncieres-geolocalisees/#/resources/d7933994-2c66-4131-a4da-cf7cd18040a4) (takes 4h locally but completes successfully) or [this DECP file](https://www.data.gouv.fr/datasets/donnees-essentielles-de-la-commande-publique-consolidees-format-tabulaire/#/resources/22847056-61df-452d-837d-8b8ceadbfc52) (in ~13min)

Insights:
- the file is read once and we store everything we need for the downstream processes (profile creation mainly)
- only the analysis on the first chunk is exhaustive, the following ones avoid testing formats that have proven to be irrelevant for the upstream chunks (we perform fewer or as many tests chunk after chunk)