### PR TITLE
perf: performance optimizations

### DIFF
--- a/csv_detective/detection/variables.py
+++ b/csv_detective/detection/variables.py
@@ -42,7 +42,17 @@ def detect_continuous_variable(
     if verbose:
         start = time()
         logging.info("Detecting continuous columns")
-    res = table.apply(lambda serie: check_threshold(serie.apply(parses_to_integer), continuous_th))
+    # Optimization: avoid double apply by using explicit loop
+    res = pd.Series(index=table.columns, dtype=bool)
+    for col in table.columns:
+        types_series = table[col].apply(parses_to_integer)
+        count = types_series.value_counts().to_dict()
+        total_nb = len(types_series)
+        if float in count:
+            nb_floats = count[float]
+            res[col] = (nb_floats / total_nb) >= continuous_th if total_nb > 0 else False
+        else:
+            res[col] = False
     if verbose:
         display_logs_depending_process_time(
             f"Detected {sum(res)} continuous columns in {round(time() - start, 3)}s",

--- a/csv_detective/parsing/csv.py
+++ b/csv_detective/parsing/csv.py
@@ -42,7 +42,8 @@ def parse_csv(
                 logging.warning(f"File is too long, analysing in chunks of {CHUNK_SIZE} rows")
             total_lines, nb_duplicates = None, None
         else:
-            nb_duplicates = len(table.loc[table.duplicated()])
+            # Optimization: use sum() on boolean mask instead of len() on filtered DataFrame
+            nb_duplicates = table.duplicated().sum()
         if num_rows > 0:
             num_rows = min(num_rows, total_lines or len(table))
             table = table.sample(num_rows, random_state=random_state)

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -76,7 +76,11 @@ def validate(
         )
 
     # hashing rows to get nb_duplicates
-    row_hashes_count = first_chunk.apply(lambda row: hash(tuple(row)), axis=1).value_counts()
+    # Optimization: use itertuples which is faster than apply(axis=1)
+    row_hashes_count = pd.Series(
+        [hash(tuple(row)) for row in first_chunk.itertuples(index=False, name=None)],
+        index=first_chunk.index,
+    ).value_counts()
     # getting values for profile to read the file only once
     col_values = {col: first_chunk[col].value_counts(dropna=False) for col in first_chunk.columns}
     analysis["total_lines"] = 0
@@ -84,10 +88,12 @@ def validate(
         if verbose:
             logging.info(f"> Testing chunk number {idx}")
         analysis["total_lines"] += len(chunk)
-        row_hashes_count = row_hashes_count.add(
-            chunk.apply(lambda row: hash(tuple(row)), axis=1).value_counts(),
-            fill_value=0,
-        )
+        # Optimization: use itertuples which is faster than apply(axis=1)
+        chunk_hashes = pd.Series(
+            [hash(tuple(row)) for row in chunk.itertuples(index=False, name=None)],
+            index=chunk.index,
+        ).value_counts()
+        row_hashes_count = row_hashes_count.add(chunk_hashes, fill_value=0)
         for col in chunk.columns:
             col_values[col] = col_values[col].add(
                 chunk[col].value_counts(dropna=False),


### PR DESCRIPTION
# Performance Optimizations Suggestions

Several performance optimizations suggested after analyzing the code and dialoging with Claude, GPT and Composer.
Since it's mostly suggested by IA, each of them needs careful reviews, but after a first pass, it seems that those are already very good leads.

I suggest we don't merge this PR as it is, but instead we cherry pick the interesting and safe optimizations one by one in dedicated PRs.

Overall improvement on tests timings if we keep all those optimizations: 31.0%** (60.97s → 42.05s, 305 tests, Python 3.13)
- `test_almost_uniform_column`: 33.7% faster (53.26s → 35.30s)
- Other tests: 12.6% faster (7.72s → 6.75s)
- No regressions detected

## 1. `test_col_val` - `.sample().apply()` on entire series

**File:** `csv_detective/parsing/columns.py:32-33`

**Problem:**
```python
def apply_test_func(serie: pd.Series, test_func: Callable, _range: int):
    return serie.sample(n=_range).apply(test_func)
```

**Line 43:** `result = apply_test_func(serie, test_func, ser_len).sum() / ser_len`

**Impact:** 
- For `test_almost_uniform_column` with 10M rows, we do:
  1. `.sample(n=10_000_000)` → O(n) to create a new Series
  2. `.apply(test_func)` → O(n) to apply the function to each element
  3. `.sum()` → O(n) to sum
- **Total: O(3n)** when we could do better

**Optimization:**
```python
# Instead of sample then apply, we can:
# Option 1: If limited_output=False, we don't need to sample!
if not limited_output:
    # Apply directly on the entire series
    result = serie.apply(test_func).sum() / len(serie)
    
# Option 2: If we really want to sample, use vectorization
# or at least avoid creating a new Series
if not limited_output:
    # Use values directly without creating a new Series
    sampled_indices = serie.sample(n=ser_len, random_state=42).index
    result = serie.loc[sampled_indices].apply(test_func).sum() / ser_len
```

## 2. `test_col` - `.apply()` on all columns for each type

**File:** `csv_detective/parsing/columns.py:98-107`

**Problem:**
```python
return_table.loc[name] = table.apply(
    lambda serie: test_col_val(serie, ...)
)
```

**Impact:**
- For each test type (int, float, date, etc.), we iterate over **all columns**
- If we have 20 test types and 10 columns, we do 200 iterations
- Each iteration calls `test_col_val` which can be slow

**Optimization:**
```python
# Instead of apply which hides a loop, use an explicit loop
# that allows early exit if necessary
for col in table.columns:
    return_table.loc[name, col] = test_col_val(
        table[col],
        attributes["func"],
        attributes["prop"],
        skipna=skipna,
        limited_output=limited_output,
        verbose=verbose,
    )
```

## 3. `test_col_val` - Unnecessary double NaN filtering

**File:** `csv_detective/parsing/columns.py:36-37`

**Problem:**
```python
if skipna:
    serie = serie[serie.notnull()]  # O(n) - creates a new Series
ser_len = len(serie)
```

Then in `apply_test_func`:
```python
serie.sample(n=_range).apply(test_func)  # O(n) - creates another new Series
```

**Impact:**
- Creation of multiple copies of Series
- If `skipna=True` and there are many NaNs, we create a complete new Series

**Optimization:**
```python
# Use non-null indices directly
if skipna:
    non_null_mask = serie.notnull()
    non_null_indices = serie[non_null_mask].index
    ser_len = len(non_null_indices)
    if ser_len == 0:
        return 1.0 if skipna else 0.0
    # Use indices directly instead of creating a new Series
    serie_to_test = serie.loc[non_null_indices]
else:
    serie_to_test = serie
    ser_len = len(serie)
```

## 4. `test_col_chunks` - `.apply(axis=1)` for hashing

**File:** `csv_detective/parsing/columns.py:171, 209`

**Problem:**
```python
row_hashes_count = table.apply(lambda row: hash(tuple(row)), axis=1).value_counts()
```

**Impact:**
- `.apply(axis=1)` is **very slow** in pandas (pure Python loop)
- For each row, we create a tuple, then hash it
- For 10k rows, that's 10k Python calls

**Optimization:**
```python
# Use a vectorized approach
def hash_rows_vectorized(df):
    # Convert each row to a tuple more efficiently
    # or use a faster hashing method
    return pd.Series(
        [hash(tuple(row)) for row in df.itertuples(index=False, name=None)],
        index=df.index
    ).value_counts()

# Or even better, use a C-optimized function
import numpy as np
def hash_rows_fast(df):
    # Use numpy to hash more quickly
    # or use pd.util.hash_pandas_object if available
    return pd.util.hash_pandas_object(df, index=False).value_counts()
```


## 5. `detect_continuous_variable` - Nested double `.apply()`

**File:** `csv_detective/detection/variables.py:45`

**Problem:**
```python
res = table.apply(lambda serie: check_threshold(serie.apply(parses_to_integer), continuous_th))
```

**Impact:**
- `.apply()` on all columns (outer loop)
- For each column, `.apply(parses_to_integer)` (inner loop)
- **O(n*m)** where n=columns, m=rows

**Optimization:**
```python
# Avoid double apply
def detect_continuous_variable_optimized(table, continuous_th=0.9, verbose=False):
    if verbose:
        start = time()
        logging.info("Detecting continuous columns")
    
    res = pd.Series(index=table.columns, dtype=bool)
    for col in table.columns:
        # Apply parses_to_integer only once
        types_series = table[col].apply(parses_to_integer)
        count = types_series.value_counts().to_dict()
        total_nb = len(types_series)
        nb_floats = count.get(float, 0)
        res[col] = (nb_floats / total_nb) >= continuous_th if total_nb > 0 else False
    
    if verbose:
        display_logs_depending_process_time(
            f"Detected {sum(res)} continuous columns in {round(time() - start, 3)}s",
            time() - start,
        )
    return res.index[res]
```


## 6. `test_col_chunks` - `value_counts()` called multiple times

**File:** `csv_detective/parsing/columns.py:173, 213-215`

**Problem:**
```python
# Line 173: value_counts on the first chunk
col_values = {col: table[col].value_counts(dropna=False) for col in table.columns}

# Line 213-215: value_counts on each batch
for col in batch.columns:
    col_values[col] = col_values[col].add(
        batch[col].value_counts(dropna=False),  # value_counts called again
        fill_value=0,
    )
```

**Impact:**
- `value_counts()` is O(n) - we do it for each column of each batch
- For a file with 100 batches and 10 columns = 1000 calls to `value_counts()`

**Optimization:**
- Already optimized (we accumulate results)
- But we could avoid recalculating `value_counts()` if we already have the data


## 7. `create_profile` - `.apply()` for float_casting

**File:** `csv_detective/output/profile.py:48, 62-64`

**Problem:**
```python
cast_col = table[c].apply(lambda x: float_casting(x) if isinstance(x, str) else pd.NA)
```

**Impact:**
- `.apply()` with lambda is slow (Python loop)
- For each value, we do `isinstance(x, str)` then `float_casting(x)`

**Optimization:**
```python
# Use pd.to_numeric with errors='coerce' which is vectorized in C
cast_col = pd.to_numeric(table[c], errors='coerce')

# Or if float_casting is necessary:
# Filter strings first, then apply
mask = table[c].apply(lambda x: isinstance(x, str))
cast_col = table[c].copy()
cast_col.loc[mask] = table[c].loc[mask].apply(float_casting)
cast_col.loc[~mask] = pd.NA
```


## 8. `parse_csv` - `.duplicated()` on entire DataFrame

**File:** `csv_detective/parsing/csv.py:45`

**Problem:**
```python
nb_duplicates = len(table.loc[table.duplicated()])
```

**Impact:**
- `table.duplicated()` creates a boolean mask of the entire table (O(n))
- `table.loc[mask]` filters (O(n))
- `len()` counts (O(n))

**Optimization:**
```python
# Use sum() directly on the boolean mask
nb_duplicates = table.duplicated().sum()
```