### PR TITLE
Add unique values list for (multi)categorical columns

### DIFF
--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -71,7 +71,7 @@ def detect_formats(
     analysis["columns_fields"] = prepare_output_dict(scores_table_fields, limited_output)
 
     # Perform testing on labels
-    scores_table_labels = test_label(analysis["header"], formats, limited_output, verbose=verbose)
+    scores_table_labels = test_label(analysis["header"], formats, verbose=verbose)
     analysis["columns_labels"] = prepare_output_dict(scores_table_labels, limited_output)
 
     # Multiply the results of the fields by 1 + 0.5 * the results of the labels.

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -8,7 +8,10 @@ from csv_detective.detection.variables import (
     # detect_continuous_variable,
 )
 from csv_detective.format import Format, FormatsManager
-from csv_detective.output.utils import prepare_output_dict
+from csv_detective.output.utils import (
+    extract_unique_from_multicat,
+    prepare_output_dict,
+)
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
     handle_empty_columns,
@@ -69,6 +72,29 @@ def detect_formats(
             verbose=verbose,
         )
     analysis["columns_fields"] = prepare_output_dict(scores_table_fields, limited_output)
+    analysis["unique_values"] = {}
+    if not in_chunks:
+        for col in table.columns:
+            if (
+                analysis["columns_fields"][col]["format"] == "json" 
+                and all(value.startswith("[") for value in table[col])
+            ):
+                unique = extract_unique_from_multicat(table[col])
+                if unique is not None:
+                    analysis["unique_values"][col] = unique
+            elif table[col].nunique() <= MAX_NUMBER_CATEGORICAL_VALUES:
+                analysis["unique_values"][col] = list(table[col].dropna().unique())
+    else:
+        for col in col_values.keys():
+            if (
+                analysis["columns_fields"][col]["format"] == "json" 
+                and all(value.startswith("[") for value in col_values[col].index)
+            ):
+                unique = extract_unique_from_multicat(col_values[col].index.to_series())
+                if unique is not None:
+                    analysis["unique_values"][col] = unique
+            elif len(col_values[col]) <= MAX_NUMBER_CATEGORICAL_VALUES:
+                analysis["unique_values"][col] = list(col_values[col].index.dropna())
 
     # Perform testing on labels
     scores_table_labels = test_label(analysis["header"], formats, verbose=verbose)

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -75,9 +75,8 @@ def detect_formats(
     analysis["unique_values"] = {}
     if not in_chunks:
         for col in table.columns:
-            if (
-                analysis["columns_fields"][col]["format"] == "json" 
-                and all(value.startswith("[") for value in table[col])
+            if analysis["columns_fields"][col]["format"] == "json" and all(
+                value.startswith("[") for value in table[col]
             ):
                 unique = extract_unique_from_multicat(table[col])
                 if unique is not None:
@@ -86,9 +85,8 @@ def detect_formats(
                 analysis["unique_values"][col] = list(table[col].dropna().unique())
     else:
         for col in col_values.keys():
-            if (
-                analysis["columns_fields"][col]["format"] == "json" 
-                and all(value.startswith("[") for value in col_values[col].index)
+            if analysis["columns_fields"][col]["format"] == "json" and all(
+                value.startswith("[") for value in col_values[col].index
             ):
                 unique = extract_unique_from_multicat(col_values[col].index.to_series())
                 if unique is not None:

--- a/csv_detective/output/utils.py
+++ b/csv_detective/output/utils.py
@@ -1,4 +1,7 @@
+import json
 import pandas as pd
+
+from csv_detective.parsing.columns import MAX_NUMBER_CATEGORICAL_VALUES
 
 
 def prepare_output_dict(return_table: pd.DataFrame, limited_output: bool):
@@ -73,3 +76,12 @@ def prepare_output_dict(return_table: pd.DataFrame, limited_output: bool):
             )
 
     return output_dict
+
+
+def extract_unique_from_multicat(values: pd.Series) -> list | None:
+    # we can safely cast as json here
+    loaded = values.apply(
+        lambda v: json.loads(v) if isinstance(v, str) else pd.NA
+    )
+    unique = loaded.explode().dropna().unique()
+    return unique.tolist() if len(unique) <= MAX_NUMBER_CATEGORICAL_VALUES else None

--- a/csv_detective/output/utils.py
+++ b/csv_detective/output/utils.py
@@ -1,4 +1,5 @@
 import json
+
 import pandas as pd
 
 from csv_detective.parsing.columns import MAX_NUMBER_CATEGORICAL_VALUES
@@ -80,8 +81,6 @@ def prepare_output_dict(return_table: pd.DataFrame, limited_output: bool):
 
 def extract_unique_from_multicat(values: pd.Series) -> list | None:
     # we can safely cast as json here
-    loaded = values.apply(
-        lambda v: json.loads(v) if isinstance(v, str) else pd.NA
-    )
+    loaded = values.apply(lambda v: json.loads(v) if isinstance(v, str) else pd.NA)
     unique = loaded.explode().dropna().unique()
     return unique.tolist() if len(unique) <= MAX_NUMBER_CATEGORICAL_VALUES else None

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -106,9 +106,7 @@ def test_col(
     return return_table
 
 
-def test_label(
-    columns: list[str], formats: dict[str, Format], verbose: bool = False
-):
+def test_label(columns: list[str], formats: dict[str, Format], verbose: bool = False):
     if verbose:
         start = time()
         logging.info("Testing labels to get formats")

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -107,7 +107,7 @@ def test_col(
 
 
 def test_label(
-    columns: list[str], formats: dict[str, Format], limited_output: bool, verbose: bool = False
+    columns: list[str], formats: dict[str, Format], verbose: bool = False
 ):
     if verbose:
         start = time()

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import pandas as pd
 
 from csv_detective.format import FormatsManager
+from csv_detective.output.utils import extract_unique_from_multicat
 from csv_detective.parsing.columns import MAX_NUMBER_CATEGORICAL_VALUES
 
 # VALIDATION_CHUNK_SIZE is bigger than (analysis) CHUNK_SIZE because
@@ -173,6 +174,17 @@ def validate(
     analysis["categorical"] = [
         col for col, values in col_values.items() if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES
     ]
+    analysis["unique_values"] = {}
+    for col in col_values.keys():
+        if (
+            previous_analysis["columns"][col]["format"] == "json" 
+            and all(value.startswith("[") for value in col_values[col].index)
+        ):
+            unique = extract_unique_from_multicat(col_values[col].index)
+            if unique is not None:
+                analysis["unique_values"][col] = unique
+        elif len(col_values[col]) <= MAX_NUMBER_CATEGORICAL_VALUES:
+            analysis["unique_values"][col] = list(col_values[col].index.dropna())
     return (
         True,
         analysis

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -176,9 +176,8 @@ def validate(
     ]
     analysis["unique_values"] = {}
     for col in col_values.keys():
-        if (
-            previous_analysis["columns"][col]["format"] == "json" 
-            and all(value.startswith("[") for value in col_values[col].index)
+        if previous_analysis["columns"][col]["format"] == "json" and all(
+            value.startswith("[") for value in col_values[col].index
         ):
             unique = extract_unique_from_multicat(col_values[col].index)
             if unique is not None:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -572,23 +572,22 @@ def test_unique_values_output(nb_rows, mocked_responses):
         cat = (
             "a"
             if k < nb_rows // 4
-            else "b" if k < nb_rows // 2
-            else "c" if k < nb_rows // 4 * 3
+            else "b"
+            if k < nb_rows // 2
+            else "c"
+            if k < nb_rows // 4 * 3
             else "d"
         )
         json_cat = (
             [1]
             if k < nb_rows // 4
-            else [1, 2] if k < nb_rows // 2
-            else [3, 2, 1] if k < nb_rows // 4 * 3
+            else [1, 2]
+            if k < nb_rows // 2
+            else [3, 2, 1]
+            if k < nb_rows // 4 * 3
             else []
         )
-        json_not_cat = (
-            [k, k + 1]
-            if k % 2 == 0
-            else [k] if k % 3 == 0
-            else []
-        )
+        json_not_cat = [k, k + 1] if k % 2 == 0 else [k] if k % 3 == 0 else []
         expected_content += f"{cat};{k};{json_cat};{json_not_cat}\n"
     mocked_responses.get(
         "http://example.com/test.csv",

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -563,3 +563,55 @@ def test_diff_epci_siren(col_name, value, expected, mocked_responses):
 )
 def test_sanitize_for_json(to_export, expected):
     assert sanitize_for_json(to_export) == expected
+
+
+@pytest.mark.parametrize("nb_rows", (CHUNK_SIZE // 10, CHUNK_SIZE + 1))
+def test_unique_values_output(nb_rows, mocked_responses):
+    expected_content = "cat;not_cat;json_cat;json_not_cat\n"
+    for k in range(nb_rows):
+        cat = (
+            "a"
+            if k < nb_rows // 4
+            else "b" if k < nb_rows // 2
+            else "c" if k < nb_rows // 4 * 3
+            else "d"
+        )
+        json_cat = (
+            [1]
+            if k < nb_rows // 4
+            else [1, 2] if k < nb_rows // 2
+            else [3, 2, 1] if k < nb_rows // 4 * 3
+            else []
+        )
+        json_not_cat = (
+            [k, k + 1]
+            if k % 2 == 0
+            else [k] if k % 3 == 0
+            else []
+        )
+        expected_content += f"{cat};{k};{json_cat};{json_not_cat}\n"
+    mocked_responses.get(
+        "http://example.com/test.csv",
+        body=expected_content,
+        status=200,
+    )
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = MagicMock()
+        mock_response.read.return_value = expected_content.encode("utf-8")
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        analysis = routine(
+            file_path="http://example.com/test.csv",
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
+    assert analysis["columns"]["json_cat"]["python_type"] == "json"
+    assert analysis["columns"]["json_not_cat"]["python_type"] == "json"
+    assert isinstance(analysis.get("unique_values"), dict)
+    # too many values => not in unique_values
+    assert "not_cat" not in analysis["unique_values"]
+    assert "json_not_cat" not in analysis["unique_values"]
+    # few enough values => testing output
+    assert analysis["unique_values"]["cat"] == ["a", "b", "c", "d"]
+    assert analysis["unique_values"]["json_cat"] == [1, 2, 3]


### PR DESCRIPTION
Adds a `unique_values` key to the output, as a dict `"col_name" : [val1, val2, ...]`, the values being the lists of unique values taken by the column, up to 25 (which is the current threshold to consider columns categorical)