### PR TITLE
fix(deps): constrain urllib3 for GHSA-mf9v-mfxr-j63j

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ csv_detective = ["CHANGELOG.md", "LICENSE", "README.md"]
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
+# Provisional: drop when dependencies require a patched urllib3 lower bound (GHSA-mf9v-mfxr-j63j).
+[tool.uv]
+constraint-dependencies = ["urllib3>=2.7.0"]
+
 [tool.ruff]
 lint = { extend-select = ["I"] } # ["I"] is to also sort imports with an isort rule
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
+
 [[package]]
 name = "certifi"
 version = "2025.11.12"
@@ -792,11 +795,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Security scanning flagged a vulnerable `urllib3` pulled in transitively (e.g. `requests`). Patched releases need `urllib3` 2.7.0 or later per [GitHub Advisory GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j).

This adds a `uv` resolution constraint so the lockfile resolves to a safe version without treating `urllib3` as an application-level dependency, and regenerates `uv.lock` accordingly.