### PR TITLE
Be less forgiving than python for ints

### DIFF
--- a/csv_detective/formats/int.py
+++ b/csv_detective/formats/int.py
@@ -8,7 +8,7 @@ labels = {"nb": 0.75, "nombre": 1, "nbre": 0.75}
 def _is(val) -> bool:
     if (
         not isinstance(val, str)
-        or any(v in val for v in [".", "_", "+"])
+        or any(v in val for v in [".", "_", "+", " ", "\t", "\n"])
         or (val.startswith("0") and len(val) > 1)
         or len(val) >= 20
     ):
@@ -22,5 +22,5 @@ def _is(val) -> bool:
 
 _test_values = {
     True: ["1", "0", "1764", "-24"],
-    False: ["01053", "1.2", "123_456", "+35", "14292405299487610865"],
+    False: ["01053", "1.2", "123_456", "+35", "14292405299487610865", "10 ", "\t10", "10\n"],
 }


### PR DESCRIPTION
python is forgiving with whitespaces (spaces, tabs, newlines) in strings when casting with `int`, for instance:
- `int("100    ")` => `100`
- `int("\t100\n")` => `100`

We may not want to be *that* forgiving