### PR TITLE
fix: fix tags naming inconsistency

### DIFF
--- a/csv_detective/formats/int.py
+++ b/csv_detective/formats/int.py
@@ -1,6 +1,6 @@
 proportion = 1
 description = "Integer"
-tag = ["type"]
+tags = ["type"]
 python_type = "int"
 labels = {"nb": 0.75, "nombre": 1, "nbre": 0.75}
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -29,7 +29,7 @@
 | id_rnb | Building identifier from the French national building reference source ([RNB](https://rnb.beta.gouv.fr/definition)) | string | fr, geo | 1 | True | `FT4RKBXBVH9S` |
 | insee_ape700 | French acitvity code from the INSEE reference source (APE) | string | fr | 0.8 | False | `0116Z` |
 | insee_canton | French canton name | string | fr, geo | 0.9 | False | `nantua` |
-| int | Integer | int |  | 1 | False | `1` |
+| int | Integer | int | type | 1 | False | `1` |
 | iso_country_code_alpha2 | [ISO alpha 2](https://fr.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code | string | geo | 1 | False | `FR` |
 | iso_country_code_alpha3 | [ISO alpha 3](https://fr.wikipedia.org/wiki/ISO_3166-1) country code | string | geo | 1 | False | `FRA` |
 | iso_country_code_numeric | [ISO numeric](https://fr.wikipedia.org/wiki/ISO_3166-1) country code | string | geo | 1 | False | `250` |


### PR DESCRIPTION
The library looks for an attribute named `tags` on each format module. It never looks for `tag`.

With `tag = ["type"]`, that attribute is ignored, so int ends up with an empty tag list. Filtering with `tags=["type"]` then skips `int`, even though the file meant to mark it as a type format.

So it's just a typo: the name must match what the code expects (tags), like every other format file.