### PR TITLE
feat: add performance benchmarking in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ parameters:
   cache-prefix:
     type: string
     default: "py-cache"
+  run-benchmarks:
+    type: boolean
+    default: false
+    description: "Set to true via Trigger Pipeline to run the performance benchmark workflow"
 
 jobs:
   install:
@@ -62,7 +66,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run pytest -s tests/ --junitxml=reports/python/tests.xml -p no:sugar --color=yes
+            uv run pytest -s tests/ -m "not slow" --junitxml=reports/python/tests.xml -p no:sugar --color=yes
       - store_test_results:
           path: reports/python
 
@@ -127,8 +131,38 @@ jobs:
           command: |
             uv publish dist/*  # use UV_PUBLISH_TOKEN
 
+  benchmark:
+    docker:
+      - image: ghcr.io/astral-sh/uv:python<< pipeline.parameters.python-version >>-bookworm
+    resource_class: large
+    environment:
+      BENCHMARK_CI: circleci
+      BENCHMARK_RUNNER_CLASS: large
+      BENCHMARK_PYTHON_VERSION: << pipeline.parameters.python-version >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run performance benchmarks
+          no_output_timeout: 30m
+          command: |
+            mkdir -p .benchmarks
+            uv run pytest tests/test_benchmark.py -v -s -m slow
+      - run:
+          name: Display benchmark results
+          command: |
+            echo "=== Benchmark Results ==="
+            cat .benchmarks/benchmarks.csv
+            echo "========================="
+          when: always
+      - store_artifacts:
+          path: .benchmarks
+          when: always
+
 workflows:
   build-deploy-publish:
+    when:
+      not: << pipeline.parameters.run-benchmarks >>
     jobs:
       - install
       - lint:
@@ -152,3 +186,11 @@ workflows:
             branches:
               only: << pipeline.parameters.publish-branch >>
           context: org-global
+
+  benchmark-workflow:
+    when: << pipeline.parameters.run-benchmarks >>
+    jobs:
+      - install
+      - benchmark:
+          requires:
+            - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           name: Display benchmark results
           command: |
             echo "=== Benchmark Results ==="
-            cat .benchmarks/benchmarks.csv
+            cat .benchmarks/benchmark.json
             echo "========================="
           when: always
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ pdm.lock
 analyse_csv.py
 data_gouv_api_download.py
 reformat_tab.py
+
+# Benchmark outputs
+.benchmarks/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,29 @@ Every modification should be submited as a PR (without touching the CHANGELOG, w
 
 Remember to format, lint, and sort imports with [Ruff](https://docs.astral.sh/ruff/) before committing (checks will remind you anyway):
 ```bash
-pip install .[dev]
-ruff check --fix .
-ruff format .
+uv sync
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+## Tests
+
+Default CI excludes slow tests. Locally, prefer the same filter so you do not run the performance canary by accident:
+
+```bash
+uv run pytest tests/ -m "not slow"
+```
+
+### Performance benchmark
+
+`tests/test_benchmark.py` is marked `@pytest.mark.slow`. It generates a large synthetic CSV and times full `routine()` runs.
+
+```bash
+# Local run
+uv run pytest tests/test_benchmark.py -m slow -v -s
+
+# CircleCI: Trigger Pipeline with run-benchmarks=true, then download
+# the CSV from the benchmark job Artifacts tab
 ```
 
 ### Doc generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,10 @@ uv run pytest tests/ -m "not slow"
 # Local run
 uv run pytest tests/test_benchmark.py -m slow -v -s
 
-# CircleCI: Trigger Pipeline with run-benchmarks=true, then download
-# the CSV from the benchmark job Artifacts tab
+# CircleCI: Trigger Pipeline with run-benchmarks=true, then check the
+# job logs or download benchmark.json from the Artifacts tab
 ```
+
 
 ### Doc generation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ local_scheme = "no-local-version"
 [tool.uv]
 constraint-dependencies = ["urllib3>=2.7.0"]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: end-to-end performance canary on large files (excluded from default CI)",
+]
+
 [tool.ruff]
 lint = { extend-select = ["I"] } # ["I"] is to also sort imports with an isort rule
 line-length = 100

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -5,6 +5,7 @@ CircleCI ``benchmark-workflow`` (pipeline parameter ``run-benchmarks=true``).
 """
 
 import csv
+import json
 import os
 import statistics
 import sys
@@ -20,21 +21,7 @@ from csv_detective import routine
 NB_ROWS = 100_000
 NB_RUNS = 3
 BENCHMARK_DIR = Path(".benchmarks")
-BENCHMARK_CSV = BENCHMARK_DIR / "benchmarks.csv"
-CSV_HEADERS = [
-    "datetime",
-    "test_name",
-    "input_file",
-    "ci",
-    "execution_time_seconds",
-    "runs",
-    "commit_id",
-    "runner_class",
-    "runner_cpu",
-    "runner_memory_mb",
-    "python_version",
-    "nb_rows",
-]
+BENCHMARK_JSON = BENCHMARK_DIR / "benchmark.json"
 
 
 def _runner_cpu() -> str:
@@ -110,38 +97,44 @@ def _median_seconds(durations: list[float]) -> float:
     return round(statistics.median(durations), 3)
 
 
-def _append_benchmark_row(
+def _write_scenario_result(
     *,
     test_name: str,
     input_file: str,
-    execution_time_seconds: float,
+    durations: list[float],
     nb_rows: int,
-) -> None:
+) -> dict:
+    """Merge this scenario into the run report JSON and return the scenario payload."""
     BENCHMARK_DIR.mkdir(parents=True, exist_ok=True)
-    write_header = not BENCHMARK_CSV.exists()
-    with BENCHMARK_CSV.open("a", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=CSV_HEADERS)
-        if write_header:
-            writer.writeheader()
-        writer.writerow(
-            {
-                "datetime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "test_name": test_name,
-                "input_file": input_file,
-                "ci": os.environ.get("BENCHMARK_CI", "local"),
-                "execution_time_seconds": execution_time_seconds,
-                "runs": NB_RUNS,
-                "commit_id": os.environ.get("CIRCLE_SHA1", "")[:7],
-                "runner_class": os.environ.get("BENCHMARK_RUNNER_CLASS", ""),
-                "runner_cpu": _runner_cpu(),
-                "runner_memory_mb": _runner_memory_mb(),
-                "python_version": os.environ.get(
-                    "BENCHMARK_PYTHON_VERSION",
-                    f"{sys.version_info.major}.{sys.version_info.minor}",
-                ),
-                "nb_rows": nb_rows,
-            }
-        )
+    if BENCHMARK_JSON.exists():
+        report = json.loads(BENCHMARK_JSON.read_text(encoding="utf-8"))
+    else:
+        report = {
+            "datetime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "ci": os.environ.get("BENCHMARK_CI", "local"),
+            "commit_id": os.environ.get("CIRCLE_SHA1", "")[:7],
+            "runner_class": os.environ.get("BENCHMARK_RUNNER_CLASS", ""),
+            "runner_cpu": _runner_cpu(),
+            "runner_memory_mb": _runner_memory_mb(),
+            "python_version": os.environ.get(
+                "BENCHMARK_PYTHON_VERSION",
+                f"{sys.version_info.major}.{sys.version_info.minor}",
+            ),
+            "nb_rows": nb_rows,
+            "input_file": input_file,
+            "scenarios": [],
+        }
+
+    scenario = {
+        "test_name": test_name,
+        "runs_seconds": [round(d, 3) for d in durations],
+        "execution_time_seconds": _median_seconds(durations),
+        "nb_runs": NB_RUNS,
+    }
+    report["scenarios"] = [s for s in report["scenarios"] if s["test_name"] != test_name]
+    report["scenarios"].append(scenario)
+    BENCHMARK_JSON.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return scenario
 
 
 def _run_timed_routine(file_path: str, *, output_profile: bool) -> tuple[dict, list[float]]:
@@ -187,14 +180,14 @@ def test_routine_big_file(benchmark_csv: Path, output_profile: bool, test_name: 
     if output_profile:
         assert "profile" in analysis
 
-    median = _median_seconds(durations)
-    _append_benchmark_row(
+    scenario = _write_scenario_result(
         test_name=test_name,
         input_file=benchmark_csv.name,
-        execution_time_seconds=median,
+        durations=durations,
         nb_rows=NB_ROWS,
     )
     print(
-        f"{test_name}: runs={durations!r} median={median}s "
+        f"{test_name}: runs={scenario['runs_seconds']!r} "
+        f"median={scenario['execution_time_seconds']}s "
         f"(nb_rows={NB_ROWS}, output_profile={output_profile})"
     )

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -18,6 +18,7 @@ from time import perf_counter
 import pytest
 
 from csv_detective import routine
+from csv_detective.parsing.csv import CHUNK_SIZE
 
 NB_ROWS = 500_000
 NB_RUNS = 3
@@ -254,6 +255,8 @@ def _assert_benchmark_detections(analysis: dict, *, output_profile: bool) -> Non
 def benchmark_csv(tmp_path_factory: pytest.TempPathFactory) -> Path:
     path = tmp_path_factory.mktemp("benchmark") / "benchmark_input.csv"
     _generate_benchmark_csv(path)
+    with path.open(encoding="utf-8") as f:
+        assert sum(1 for _ in f) - 1 == NB_ROWS
     return path
 
 
@@ -271,7 +274,9 @@ def test_routine_big_file(benchmark_csv: Path, output_profile: bool, test_name: 
         output_profile=output_profile,
     )
 
-    assert analysis["total_lines"] == NB_ROWS
+    # Format detection may stop reading before EOF once every column is resolved
+    # (see test_col_chunks early stop); total_lines is rows processed, not file size.
+    assert CHUNK_SIZE <= analysis["total_lines"] <= NB_ROWS
     assert analysis["columns"]
     assert analysis["header"]
     _assert_benchmark_detections(analysis, output_profile=output_profile)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -24,6 +24,26 @@ BENCHMARK_DIR = Path(".benchmarks")
 BENCHMARK_JSON = BENCHMARK_DIR / "benchmark.json"
 
 
+def _siren_luhn_check_digit(prefix: str) -> str:
+    """Return the 9th digit that satisfies the SIREN Luhn key for an 8-digit prefix."""
+    for check in range(10):
+        candidate = f"{prefix}{check}"
+        cle = 0
+        pair = False
+        for digit in candidate:
+            y = int(digit) * (1 + pair)
+            cle += y // 10 + y % 10
+            pair = not pair
+        if cle % 10 == 0:
+            return str(check)
+    raise ValueError(f"Could not compute SIREN check digit for prefix {prefix}")
+
+
+def _random_valid_siren(rng: Random) -> str:
+    prefix = f"{rng.randint(0, 99_999_999):08d}"
+    return prefix + _siren_luhn_check_digit(prefix)
+
+
 def _runner_cpu() -> str:
     if cpu := os.environ.get("BENCHMARK_RUNNER_CPU"):
         return cpu
@@ -84,7 +104,7 @@ def _generate_benchmark_csv(path: Path, nb_rows: int = NB_ROWS, seed: int = 42) 
                     round(rng.uniform(0, 100), 2),
                     (start + timedelta(days=rng.randint(0, 1500))).isoformat(),
                     rng.choice(communes),
-                    f"{rng.randint(100_000_000, 999_999_999)}",
+                    _random_valid_siren(rng),
                     f"row-{i}-note-{rng.randint(0, 9999)}",
                     round(rng.uniform(41.0, 51.0), 6),
                     round(rng.uniform(-5.0, 10.0), 6),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -148,8 +148,8 @@ def _run_timed_routine(file_path: str, *, output_profile: bool) -> tuple[dict, l
             output_profile=output_profile,
             save_results=False,
         )
+        assert analysis is not None
         durations.append(perf_counter() - start)
-    assert analysis is not None
     return analysis, durations
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,200 @@
+"""Slow end-to-end performance canary for csv-detective.
+
+Excluded from default CI via ``pytest -m "not slow"``. Run manually or via the
+CircleCI ``benchmark-workflow`` (pipeline parameter ``run-benchmarks=true``).
+"""
+
+import csv
+import os
+import statistics
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from random import Random
+from time import perf_counter
+
+import pytest
+
+from csv_detective import routine
+
+NB_ROWS = 100_000
+NB_RUNS = 3
+BENCHMARK_DIR = Path(".benchmarks")
+BENCHMARK_CSV = BENCHMARK_DIR / "benchmarks.csv"
+CSV_HEADERS = [
+    "datetime",
+    "test_name",
+    "input_file",
+    "ci",
+    "execution_time_seconds",
+    "runs",
+    "commit_id",
+    "runner_class",
+    "runner_cpu",
+    "runner_memory_mb",
+    "python_version",
+    "nb_rows",
+]
+
+
+def _runner_cpu() -> str:
+    if cpu := os.environ.get("BENCHMARK_RUNNER_CPU"):
+        return cpu
+    return str(os.cpu_count() or "")
+
+
+def _runner_memory_mb() -> str:
+    if memory := os.environ.get("BENCHMARK_RUNNER_MEMORY_MB"):
+        return memory
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page_size > 0:
+            return str((pages * page_size) // (1024 * 1024))
+    except (AttributeError, OSError, ValueError):
+        pass
+    return ""
+
+
+def _generate_benchmark_csv(path: Path, nb_rows: int = NB_ROWS, seed: int = 42) -> None:
+    """Generate a reproducible mixed-type CSV large enough to exercise chunking."""
+    rng = Random(seed)
+    communes = [
+        "Paris",
+        "Lyon",
+        "Marseille",
+        "Toulouse",
+        "Nice",
+        "Nantes",
+        "Montpellier",
+        "Strasbourg",
+        "Bordeaux",
+        "Lille",
+    ]
+    start = date(2020, 1, 1)
+
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(
+            [
+                "id",
+                "amount",
+                "ratio",
+                "event_date",
+                "commune",
+                "siren",
+                "description",
+                "latitude",
+                "longitude",
+                "code_postal",
+            ]
+        )
+        for i in range(nb_rows):
+            writer.writerow(
+                [
+                    i,
+                    rng.randint(0, 1_000_000),
+                    round(rng.uniform(0, 100), 2),
+                    (start + timedelta(days=rng.randint(0, 1500))).isoformat(),
+                    communes[rng.randint(0, len(communes) - 1)],
+                    f"{rng.randint(100_000_000, 999_999_999)}",
+                    f"row-{i}-note-{rng.randint(0, 9999)}",
+                    round(rng.uniform(41.0, 51.0), 6),
+                    round(rng.uniform(-5.0, 10.0), 6),
+                    f"{rng.randint(1000, 95999):05d}",
+                ]
+            )
+
+
+def _median_seconds(durations: list[float]) -> float:
+    return round(statistics.median(durations), 3)
+
+
+def _append_benchmark_row(
+    *,
+    test_name: str,
+    input_file: str,
+    execution_time_seconds: float,
+    nb_rows: int,
+) -> None:
+    BENCHMARK_DIR.mkdir(parents=True, exist_ok=True)
+    write_header = not BENCHMARK_CSV.exists()
+    with BENCHMARK_CSV.open("a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_HEADERS)
+        if write_header:
+            writer.writeheader()
+        writer.writerow(
+            {
+                "datetime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "test_name": test_name,
+                "input_file": input_file,
+                "ci": os.environ.get("BENCHMARK_CI", "local"),
+                "execution_time_seconds": execution_time_seconds,
+                "runs": NB_RUNS,
+                "commit_id": os.environ.get("CIRCLE_SHA1", "")[:7],
+                "runner_class": os.environ.get("BENCHMARK_RUNNER_CLASS", ""),
+                "runner_cpu": _runner_cpu(),
+                "runner_memory_mb": _runner_memory_mb(),
+                "python_version": os.environ.get(
+                    "BENCHMARK_PYTHON_VERSION",
+                    f"{sys.version_info.major}.{sys.version_info.minor}",
+                ),
+                "nb_rows": nb_rows,
+            }
+        )
+
+
+def _run_timed_routine(file_path: str, *, output_profile: bool) -> tuple[dict, list[float]]:
+    durations: list[float] = []
+    analysis: dict | None = None
+    for _ in range(NB_RUNS):
+        start = perf_counter()
+        analysis = routine(
+            file_path=file_path,
+            num_rows=-1,
+            output_profile=output_profile,
+            save_results=False,
+        )
+        durations.append(perf_counter() - start)
+    assert analysis is not None
+    return analysis, durations
+
+
+@pytest.fixture(scope="module")
+def benchmark_csv(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    path = tmp_path_factory.mktemp("benchmark") / "benchmark_input.csv"
+    _generate_benchmark_csv(path)
+    return path
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "output_profile,test_name",
+    [
+        (False, "test_routine_big_file"),
+        (True, "test_routine_big_file_with_profile"),
+    ],
+)
+def test_routine_big_file(benchmark_csv: Path, output_profile: bool, test_name: str):
+    analysis, durations = _run_timed_routine(
+        str(benchmark_csv),
+        output_profile=output_profile,
+    )
+
+    assert analysis["total_lines"] == NB_ROWS
+    assert analysis["columns"]
+    assert analysis["header"]
+    if output_profile:
+        assert "profile" in analysis
+
+    median = _median_seconds(durations)
+    _append_benchmark_row(
+        test_name=test_name,
+        input_file=benchmark_csv.name,
+        execution_time_seconds=median,
+        nb_rows=NB_ROWS,
+    )
+    print(
+        f"{test_name}: runs={durations!r} median={median}s "
+        f"(nb_rows={NB_ROWS}, output_profile={output_profile})"
+    )

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -83,7 +83,7 @@ def _generate_benchmark_csv(path: Path, nb_rows: int = NB_ROWS, seed: int = 42) 
                     rng.randint(0, 1_000_000),
                     round(rng.uniform(0, 100), 2),
                     (start + timedelta(days=rng.randint(0, 1500))).isoformat(),
-                    communes[rng.randint(0, len(communes) - 1)],
+                    rng.choice(communes),
                     f"{rng.randint(100_000_000, 999_999_999)}",
                     f"row-{i}-note-{rng.randint(0, 9999)}",
                     round(rng.uniform(41.0, 51.0), 6),

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -9,6 +9,7 @@ import json
 import os
 import statistics
 import sys
+from collections.abc import Callable
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from random import Random
@@ -22,6 +23,34 @@ NB_ROWS = 500_000
 NB_RUNS = 3
 BENCHMARK_DIR = Path(".benchmarks")
 BENCHMARK_JSON = BENCHMARK_DIR / "benchmark.json"
+
+VALID_COMMUNES = [
+    "Paris",
+    "Lyon",
+    "Marseille",
+    "Toulouse",
+    "Nice",
+    "Nantes",
+    "Montpellier",
+    "Strasbourg",
+    "Bordeaux",
+    "Lille",
+]
+VALID_POSTCODES = [
+    "75020",
+    "01000",
+    "13001",
+    "69001",
+    "33000",
+    "59000",
+    "44000",
+    "67000",
+    "34000",
+    "06000",
+]
+INVALID_POSTCODES = ["77777", "00000", "99999"]
+VALID_DEPARTMENTS = ["75", "69", "13", "33", "59", "67", "44", "06", "2A", "974"]
+INVALID_COMMUNE = "Unknown"
 
 
 def _siren_luhn_check_digit(prefix: str) -> str:
@@ -42,6 +71,18 @@ def _siren_luhn_check_digit(prefix: str) -> str:
 def _random_valid_siren(rng: Random) -> str:
     prefix = f"{rng.randint(0, 99_999_999):08d}"
     return prefix + _siren_luhn_check_digit(prefix)
+
+
+def _pick_mostly_valid(
+    rng: Random,
+    *,
+    valid: Callable[[], str],
+    invalid: Callable[[], str],
+    invalid_rate: float,
+) -> str:
+    if rng.random() < invalid_rate:
+        return invalid()
+    return valid()
 
 
 def _runner_cpu() -> str:
@@ -66,18 +107,6 @@ def _runner_memory_mb() -> str:
 def _generate_benchmark_csv(path: Path, nb_rows: int = NB_ROWS, seed: int = 42) -> None:
     """Generate a reproducible mixed-type CSV large enough to exercise chunking."""
     rng = Random(seed)
-    communes = [
-        "Paris",
-        "Lyon",
-        "Marseille",
-        "Toulouse",
-        "Nice",
-        "Nantes",
-        "Montpellier",
-        "Strasbourg",
-        "Bordeaux",
-        "Lille",
-    ]
     start = date(2020, 1, 1)
 
     with path.open("w", newline="", encoding="utf-8") as f:
@@ -86,29 +115,62 @@ def _generate_benchmark_csv(path: Path, nb_rows: int = NB_ROWS, seed: int = 42) 
             [
                 "id",
                 "amount",
+                "quantity",
                 "ratio",
                 "event_date",
+                "event_datetime",
                 "commune",
+                "ville",
                 "siren",
+                "org_id",
+                "departement",
+                "code_postal",
+                "optional_note",
                 "description",
                 "latitude",
                 "longitude",
-                "code_postal",
             ]
         )
         for i in range(nb_rows):
+            event_day = start + timedelta(days=rng.randint(0, 1500))
+            event_dt = datetime.combine(event_day, datetime.min.time()) + timedelta(
+                hours=rng.randint(0, 23),
+                minutes=rng.randint(0, 59),
+                seconds=rng.randint(0, 59),
+            )
             writer.writerow(
                 [
                     i,
                     rng.randint(0, 1_000_000),
+                    _pick_mostly_valid(
+                        rng,
+                        valid=lambda: str(rng.randint(1, 9999)),
+                        invalid=lambda: "bad",
+                        invalid_rate=0.02,
+                    ),
                     round(rng.uniform(0, 100), 2),
-                    (start + timedelta(days=rng.randint(0, 1500))).isoformat(),
-                    rng.choice(communes),
+                    event_day.isoformat(),
+                    event_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                    rng.choice(VALID_COMMUNES),
+                    _pick_mostly_valid(
+                        rng,
+                        valid=lambda: rng.choice(VALID_COMMUNES),
+                        invalid=lambda: INVALID_COMMUNE,
+                        invalid_rate=0.15,
+                    ),
                     _random_valid_siren(rng),
+                    _random_valid_siren(rng),
+                    rng.choice(VALID_DEPARTMENTS),
+                    _pick_mostly_valid(
+                        rng,
+                        valid=lambda: rng.choice(VALID_POSTCODES),
+                        invalid=lambda: rng.choice(INVALID_POSTCODES),
+                        invalid_rate=0.08,
+                    ),
+                    "" if rng.random() < 0.30 else f"note-{rng.randint(0, 9999)}",
                     f"row-{i}-note-{rng.randint(0, 9999)}",
                     round(rng.uniform(41.0, 51.0), 6),
                     round(rng.uniform(-5.0, 10.0), 6),
-                    f"{rng.randint(1000, 95999):05d}",
                 ]
             )
 
@@ -173,6 +235,21 @@ def _run_timed_routine(file_path: str, *, output_profile: bool) -> tuple[dict, l
     return analysis, durations
 
 
+def _assert_benchmark_detections(analysis: dict, *, output_profile: bool) -> None:
+    columns = analysis["columns"]
+    assert columns["event_date"]["format"] == "date"
+    assert columns["event_datetime"]["format"] == "datetime_naive"
+    assert columns["commune"]["format"] == "commune"
+    assert columns["ville"]["format"] == "commune"
+    assert columns["siren"]["format"] == "siren"
+    assert columns["org_id"]["format"] != "siren"
+    assert columns["departement"]["format"] == "code_departement"
+    assert columns["code_postal"]["format"] == "code_postal"
+    assert columns["quantity"]["format"] == "string"
+    if output_profile:
+        assert analysis["profile"]["optional_note"]["nb_missing_values"] > 0
+
+
 @pytest.fixture(scope="module")
 def benchmark_csv(tmp_path_factory: pytest.TempPathFactory) -> Path:
     path = tmp_path_factory.mktemp("benchmark") / "benchmark_input.csv"
@@ -197,6 +274,7 @@ def test_routine_big_file(benchmark_csv: Path, output_profile: bool, test_name: 
     assert analysis["total_lines"] == NB_ROWS
     assert analysis["columns"]
     assert analysis["header"]
+    _assert_benchmark_detections(analysis, output_profile=output_profile)
     if output_profile:
         assert "profile" in analysis
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -18,7 +18,7 @@ import pytest
 
 from csv_detective import routine
 
-NB_ROWS = 100_000
+NB_ROWS = 500_000
 NB_RUNS = 3
 BENCHMARK_DIR = Path(".benchmarks")
 BENCHMARK_JSON = BENCHMARK_DIR / "benchmark.json"


### PR DESCRIPTION
We currently have no reliable/deterministic way to measure csv-detective’s end-to-end performance before and after an optimization: the regular test suite only uses small files and never records runtime.

This adds a manually triggered CircleCI benchmark that generates a large synthetic CSV, times full analysis runs (with and without profiling), and publishes the results as a CircleCI job artifact so future performance work can be evaluated on a comparable baseline without slowing down everyday CI.

Example result from CircleCI artifacts after a few runs on this branch:

```json
=== Benchmark Results ===
{
  "datetime": "2026-07-17T15:35:16Z",
  "ci": "circleci",
  "commit_id": "4626c25",
  "runner_class": "large",
  "runner_cpu": "36",
  "runner_memory_mb": "70299",
  "python_version": "3.11",
  "nb_rows": 500000,
  "input_file": "benchmark_input.csv",
  "scenarios": [
    {
      "test_name": "test_routine_big_file",
      "runs_seconds": [
        45.905,
        52.973,
        53.259
      ],
      "execution_time_seconds": 52.973,
      "nb_runs": 3
    },
    {
      "test_name": "test_routine_big_file_with_profile",
      "runs_seconds": [
        42.799,
        45.091,
        43.111
      ],
      "execution_time_seconds": 43.111,
      "nb_runs": 3
    }
  ]
}
=========================
```


```json
=== Benchmark Results ===
{
  "datetime": "2026-07-17T15:47:58Z",
  "ci": "circleci",
  "commit_id": "4626c25",
  "runner_class": "large",
  "runner_cpu": "36",
  "runner_memory_mb": "70299",
  "python_version": "3.14",
  "nb_rows": 500000,
  "input_file": "benchmark_input.csv",
  "scenarios": [
    {
      "test_name": "test_routine_big_file",
      "runs_seconds": [
        42.038,
        40.293,
        39.591
      ],
      "execution_time_seconds": 40.293,
      "nb_runs": 3
    },
    {
      "test_name": "test_routine_big_file_with_profile",
      "runs_seconds": [
        39.597,
        40.766,
        40.969
      ],
      "execution_time_seconds": 40.766,
      "nb_runs": 3
    }
  ]
}
=========================
```