### PR TITLE
ci: run tests on Python 3.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   python-version:
     type: string
-    default: "3.11"
+    default: "3.14"
   publish-branch:
     type: string
     default: "main"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -715,6 +715,7 @@ def test_custom_na_values(custom_na, nb_rows):
     expected_content = "a,b\n" + "99,10.0\n" * nb_rows + "Non spécifié,Non spécifié\n"
     with NamedTemporaryFile() as tmp:
         tmp.write(expected_content.encode("utf-8"))
+        tmp.flush()
         analysis, df_chunks = routine(
             file_path=tmp.name,
             num_rows=-1,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -243,6 +243,7 @@ def test_validation_with_custom_na(nb_rows):
     expected_content = "a,b\n" + "99,10.0\n" * nb_rows + f"{new_na},{new_na}\n"
     with NamedTemporaryFile() as tmp:
         tmp.write(expected_content.encode("utf-8"))
+        tmp.flush()
         analysis = routine(
             file_path=tmp.name,
             num_rows=-1,


### PR DESCRIPTION
Flush NamedTemporaryFile buffers before reading by path, required since Python 3.14 no longer exposes unflushed writes via the temp file name.