### PR TITLE
feat: rugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a package to **automatically detect column content in tabular files**. T
 
 Currently supported file types: csv(.gz), xls, xlsx, ods, parquet.
 
+Tabular I/O uses [Rugo](https://rugo.dev/) for Parquet files and a stdlib CSV reader for CSV (preserving raw string values). Excel files are still read via pandas. Format detection runs on pandas DataFrames.
+
 You can also directly feed the URL of a remote file (from data.gouv.fr for instance).
 
 ## How To?
@@ -192,7 +194,6 @@ Only the format with highest score is present in the output.
 
 - Smarter refactors
 - Performances improvements
-- Test other ways to load and process data (`pandas` alternatives)
 - Add more and more detection modules...
 
 Related ideas:

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -8,11 +8,11 @@ from csv_detective.detection.variables import (
     # detect_continuous_variable,
 )
 from csv_detective.format import Format, FormatsManager
+from csv_detective.io.parquet import ParquetTable
 from csv_detective.output.utils import (
     extract_unique_from_multicat,
     prepare_output_dict,
 )
-from csv_detective.io.parquet import ParquetTable
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
     handle_empty_columns,

--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
-import pyarrow.parquet as pq
 
 from csv_detective.detection.variables import (
     detect_categorical_variable,
@@ -13,6 +12,7 @@ from csv_detective.output.utils import (
     extract_unique_from_multicat,
     prepare_output_dict,
 )
+from csv_detective.io.parquet import ParquetTable
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
     handle_empty_columns,
@@ -24,7 +24,7 @@ from csv_detective.parsing.columns import (
 
 
 def detect_formats(
-    table: pd.DataFrame | pq.ParquetFile,
+    table: pd.DataFrame | ParquetTable,
     analysis: dict,
     file_path: str,
     tags: list[str] | None = None,

--- a/csv_detective/io/__init__.py
+++ b/csv_detective/io/__init__.py
@@ -1,0 +1,4 @@
+from csv_detective.io.csv import read_csv
+from csv_detective.io.parquet import ParquetTable, load_parquet
+
+__all__ = ["ParquetTable", "load_parquet", "read_csv"]

--- a/csv_detective/io/csv.py
+++ b/csv_detective/io/csv.py
@@ -152,6 +152,7 @@ def _read_csv_stdlib(
             return _rows_to_dataframe(rows, column_names, null_values)
 
         if chunksize is not None:
+
             def _chunk_iterator() -> Iterator[pd.DataFrame]:
                 try:
                     while True:

--- a/csv_detective/io/csv.py
+++ b/csv_detective/io/csv.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import csv
+import gzip
+from collections.abc import Iterator
+from io import BytesIO, TextIOWrapper
+from typing import BinaryIO, TextIO
+
+import pandas as pd
+
+from csv_detective.utils import is_url
+
+DEFAULT_NA_VALUES = list(pd._libs.parsers.STR_NA_VALUES)
+
+
+def _normalize_column_names(names: list[str]) -> list[str]:
+    return [name if name else f"Unnamed: {idx}" for idx, name in enumerate(names)]
+
+
+def _get_null_values(
+    na_values: list[str] | str | None,
+    keep_default_na: bool,
+) -> set[str]:
+    values: list[str] = []
+    if keep_default_na:
+        values.extend(DEFAULT_NA_VALUES)
+    if na_values is None:
+        return set(values)
+    if isinstance(na_values, list):
+        values.extend(na_values)
+    else:
+        values.append(na_values)
+    return set(values)
+
+
+def _read_header_names(file_obj: TextIO, sep: str, skiprows: int | None) -> list[str]:
+    for _ in range(skiprows or 0):
+        file_obj.readline()
+    header_line = file_obj.readline()
+    return _normalize_column_names(next(csv.reader([header_line], delimiter=sep)))
+
+
+def _rows_to_dataframe(
+    rows: list[list[str]],
+    column_names: list[str],
+    null_values: set[str],
+) -> pd.DataFrame:
+    if not rows:
+        return pd.DataFrame(columns=column_names).astype(str)
+    width = len(column_names)
+    padded_rows = [row[:width] + [""] * max(0, width - len(row)) for row in rows]
+    dataframe = pd.DataFrame(padded_rows, columns=column_names, dtype=object)
+    if null_values:
+        dataframe = dataframe.replace(list(null_values), pd.NA)
+    for column in dataframe.columns:
+        dataframe[column] = dataframe[column].map(
+            lambda value: pd.NA if pd.isna(value) else str(value)
+        )
+    return dataframe
+
+
+def _open_text_file(
+    filepath_or_buffer: str | TextIO | BinaryIO,
+    encoding: str | None,
+    compression: str | None,
+) -> tuple[TextIO, bool]:
+    if isinstance(filepath_or_buffer, str):
+        if compression == "gzip" or filepath_or_buffer.endswith(".gz"):
+            return (
+                gzip.open(filepath_or_buffer, mode="rt", encoding=encoding or "utf-8", newline=""),
+                True,
+            )
+        return open(filepath_or_buffer, encoding=encoding or "utf-8", newline=""), True
+
+    filepath_or_buffer.seek(0)
+    if isinstance(filepath_or_buffer, (BytesIO, BinaryIO)) and not isinstance(
+        filepath_or_buffer, TextIO
+    ):
+        text_file = TextIOWrapper(filepath_or_buffer, encoding=encoding or "utf-8", newline="")
+        return text_file, False
+    return filepath_or_buffer, False
+
+
+def _iter_csv_rows(
+    file_obj: TextIO,
+    sep: str,
+    skiprows: int | None,
+    column_names: list[str],
+) -> Iterator[list[str]]:
+    for _ in range(skiprows or 0):
+        file_obj.readline()
+    file_obj.readline()  # header row already parsed separately
+    reader = csv.reader(file_obj, delimiter=sep)
+    for row in reader:
+        yield row
+
+
+def _read_csv_pandas(
+    filepath_or_buffer: str | TextIO | BinaryIO,
+    *,
+    sep: str,
+    dtype: type | str | None,
+    encoding: str | None,
+    skiprows: int | None,
+    nrows: int | None,
+    chunksize: int | None,
+    compression: str | None,
+    na_values: list[str] | str | None,
+    keep_default_na: bool,
+) -> pd.DataFrame | Iterator[pd.DataFrame]:
+    return pd.read_csv(
+        filepath_or_buffer,
+        sep=sep,
+        dtype=dtype,
+        encoding=encoding,
+        skiprows=skiprows,
+        nrows=nrows,
+        chunksize=chunksize,
+        compression=compression,
+        na_values=na_values,
+        keep_default_na=keep_default_na,
+        engine="c",
+    )
+
+
+def _read_csv_stdlib(
+    filepath_or_buffer: str | TextIO | BinaryIO,
+    *,
+    sep: str,
+    encoding: str | None,
+    skiprows: int | None,
+    nrows: int | None,
+    chunksize: int | None,
+    compression: str | None,
+    na_values: list[str] | str | None,
+    keep_default_na: bool,
+) -> pd.DataFrame | Iterator[pd.DataFrame]:
+    file_obj, must_close = _open_text_file(filepath_or_buffer, encoding, compression)
+    try:
+        column_names = _read_header_names(file_obj, sep, skiprows)
+        file_obj.seek(0)
+        null_values = _get_null_values(na_values, keep_default_na)
+        row_iterator = _iter_csv_rows(file_obj, sep, skiprows, column_names)
+
+        def _consume(max_rows: int) -> pd.DataFrame:
+            rows = []
+            for _ in range(max_rows):
+                try:
+                    rows.append(next(row_iterator))
+                except StopIteration:
+                    break
+            return _rows_to_dataframe(rows, column_names, null_values)
+
+        if chunksize is not None:
+            def _chunk_iterator() -> Iterator[pd.DataFrame]:
+                try:
+                    while True:
+                        chunk = _consume(chunksize)
+                        if chunk.empty:
+                            break
+                        yield chunk
+                finally:
+                    if must_close:
+                        file_obj.close()
+
+            return _chunk_iterator()
+
+        try:
+            limit = nrows if nrows is not None else None
+            if limit is None:
+                rows = list(row_iterator)
+                return _rows_to_dataframe(rows, column_names, null_values)
+            return _consume(limit)
+        finally:
+            if must_close:
+                file_obj.close()
+    except Exception:
+        if must_close:
+            file_obj.close()
+        raise
+
+
+def read_csv(
+    filepath_or_buffer: str | TextIO | BinaryIO,
+    *,
+    sep: str = ",",
+    dtype: type | str | None = str,
+    encoding: str | None = None,
+    skiprows: int | None = None,
+    nrows: int | None = None,
+    chunksize: int | None = None,
+    compression: str | None = None,
+    na_values: list[str] | str | None = None,
+    keep_default_na: bool = True,
+    **kwargs,
+) -> pd.DataFrame | Iterator[pd.DataFrame]:
+    if kwargs:
+        raise TypeError(f"Unsupported read_csv arguments: {', '.join(sorted(kwargs))}")
+
+    if isinstance(filepath_or_buffer, str) and is_url(filepath_or_buffer):
+        return _read_csv_pandas(
+            filepath_or_buffer,
+            sep=sep,
+            dtype=dtype,
+            encoding=encoding,
+            skiprows=skiprows,
+            nrows=nrows,
+            chunksize=chunksize,
+            compression=compression,
+            na_values=na_values,
+            keep_default_na=keep_default_na,
+        )
+
+    if compression not in (None, "infer", "gzip") and not (
+        isinstance(filepath_or_buffer, str) and filepath_or_buffer.endswith(".gz")
+    ):
+        return _read_csv_pandas(
+            filepath_or_buffer,
+            sep=sep,
+            dtype=dtype,
+            encoding=encoding,
+            skiprows=skiprows,
+            nrows=nrows,
+            chunksize=chunksize,
+            compression=compression,
+            na_values=na_values,
+            keep_default_na=keep_default_na,
+        )
+
+    return _read_csv_stdlib(
+        filepath_or_buffer,
+        sep=sep,
+        encoding=encoding,
+        skiprows=skiprows,
+        nrows=nrows,
+        chunksize=chunksize,
+        compression=compression,
+        na_values=na_values,
+        keep_default_na=keep_default_na,
+    )

--- a/csv_detective/io/parquet.py
+++ b/csv_detective/io/parquet.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from io import BytesIO
+from typing import BinaryIO
+
+import pandas as pd
+import requests
+from rugo import parquet as rugo_parquet
+
+from csv_detective.utils import is_url
+
+RUGO_TYPE_TO_PYTHON: dict[str, str] = {
+    "varchar": "string",
+    "int64": "int",
+    "int32": "int",
+    "float64": "float",
+    "float32": "float",
+    "boolean": "bool",
+    "date32[day]": "date",
+    "timestamp[ns]": "datetime_naive",
+    "timestamp[us]": "datetime_naive",
+    "timestamp[ms]": "datetime_naive",
+    "binary": "binary",
+}
+
+
+@dataclass(frozen=True)
+class SchemaColumn:
+    name: str
+    logical_type: str
+    physical_type: str
+    nullable: bool
+
+
+def _decode_column_name(name: str | bytes) -> str:
+    if isinstance(name, bytes):
+        return name.decode("utf-8")
+    return name
+
+
+def rugo_logical_type_to_python(logical_type: str) -> str:
+    if logical_type.startswith("array"):
+        return "json"
+    if logical_type.startswith("timestamp[") and "," in logical_type:
+        return "datetime_aware"
+    if logical_type in RUGO_TYPE_TO_PYTHON:
+        return RUGO_TYPE_TO_PYTHON[logical_type]
+    for pattern, python_type in (
+        (r"^timestamp\[", "datetime_naive"),
+        (r"^decimal", "float"),
+        (r"^struct", "json"),
+        (r"^map", "json"),
+    ):
+        if re.search(pattern, logical_type):
+            return python_type
+    raise ValueError(f"Unknown Rugo logical type: {logical_type}")
+
+
+def _load_source(file_path: str) -> str | bytes:
+    if is_url(file_path):
+        response = requests.get(file_path, allow_redirects=True)
+        response.raise_for_status()
+        return response.content
+    return file_path
+
+
+def _morsel_to_dataframe(morsel) -> pd.DataFrame:
+    column_names = [_decode_column_name(name) for name in morsel.column_names]
+    data = {
+        column_name: morsel.column(raw_name).to_pylist()
+        for column_name, raw_name in zip(column_names, morsel.column_names, strict=True)
+    }
+    return pd.DataFrame(data)
+
+
+def _iter_morsel_slices(morsel, batch_size: int) -> Iterator[pd.DataFrame]:
+    total_rows = len(morsel)
+    if total_rows == 0:
+        yield pd.DataFrame(columns=[_decode_column_name(name) for name in morsel.column_names])
+        return
+    for start in range(0, total_rows, batch_size):
+        end = min(start + batch_size, total_rows)
+        slice_morsel = morsel.slice(start, end - start)
+        yield _morsel_to_dataframe(slice_morsel)
+
+
+class ParquetTable:
+    """Parquet file handle backed by Rugo metadata and streaming reads."""
+
+    def __init__(self, source: str | bytes):
+        self._source = source
+        self._metadata = rugo_parquet.read_metadata(source)
+
+    @property
+    def schema_columns(self) -> tuple[SchemaColumn, ...]:
+        return tuple(
+            SchemaColumn(
+                name=column.name,
+                logical_type=column.logical_type,
+                physical_type=column.physical_type,
+                nullable=column.nullable,
+            )
+            for column in self._metadata.schema_columns
+        )
+
+    @property
+    def column_names(self) -> list[str]:
+        return [column.name for column in self.schema_columns]
+
+    @property
+    def num_rows(self) -> int:
+        return self._metadata.num_rows
+
+    def iter_batches(self, batch_size: int) -> Iterator[pd.DataFrame]:
+        with rugo_parquet.read_parquet(self._source) as reader:
+            for morsel in reader:
+                yield from _iter_morsel_slices(morsel, batch_size)
+
+    def iter_dataframes(self, batch_size: int) -> Iterator[pd.DataFrame]:
+        yield from self.iter_batches(batch_size)
+
+    def read_all(self) -> pd.DataFrame:
+        batches = list(self.iter_batches(batch_size=self.num_rows or 1))
+        if not batches:
+            return pd.DataFrame(columns=self.column_names)
+        return pd.concat(batches, ignore_index=True)
+
+
+def load_parquet(file_path: str) -> ParquetTable:
+    return ParquetTable(_load_source(file_path))
+
+
+def load_parquet_from_buffer(buffer: BinaryIO | BytesIO) -> ParquetTable:
+    buffer.seek(0)
+    return ParquetTable(buffer.read())

--- a/csv_detective/output/__init__.py
+++ b/csv_detective/output/__init__.py
@@ -3,8 +3,8 @@ import os
 from typing import Iterator
 
 import pandas as pd
-import pyarrow.parquet as pq
 
+from csv_detective.io.parquet import ParquetTable
 from csv_detective.output.dataframe import cast_df_chunks
 from csv_detective.output.profile import create_profile
 from csv_detective.output.schema import generate_table_schema
@@ -12,7 +12,7 @@ from csv_detective.utils import is_url, sanitize_for_json
 
 
 def generate_output(
-    table: pd.DataFrame | pq.ParquetFile,
+    table: pd.DataFrame | ParquetTable,
     analysis: dict,
     file_path: str,
     num_rows: int = 500,

--- a/csv_detective/output/dataframe.py
+++ b/csv_detective/output/dataframe.py
@@ -4,12 +4,13 @@ from time import time
 from typing import Iterator
 
 import pandas as pd
-import pyarrow.parquet as pq
 
 from csv_detective.formats.binary import binary_casting
 from csv_detective.formats.bool import bool_casting
 from csv_detective.formats.date import date_casting
 from csv_detective.formats.float import float_casting
+from csv_detective.io.csv import read_csv
+from csv_detective.io.parquet import ParquetTable, load_parquet
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import display_logs_depending_process_time
 
@@ -68,7 +69,7 @@ def cast_df(
 
 
 def cast_df_chunks(
-    df: pd.DataFrame | pq.ParquetFile,
+    df: pd.DataFrame | ParquetTable,
     analysis: dict,
     file_path: str,
     cast_json: bool = True,
@@ -78,7 +79,7 @@ def cast_df_chunks(
     if analysis.get("engine") or analysis["total_lines"] <= CHUNK_SIZE:
         # the file is loaded in one chunk, so returning the cast df
         if analysis.get("engine") == "parquet":
-            yield pd.read_parquet(file_path)
+            yield load_parquet(file_path).read_all()
         else:
             yield cast_df(
                 df=df,
@@ -88,7 +89,7 @@ def cast_df_chunks(
             )
     else:
         # loading the csv in chunks using the analysis
-        chunks = pd.read_csv(
+        chunks = read_csv(
             file_path,
             dtype=str,
             sep=analysis["separator"],

--- a/csv_detective/output/profile.py
+++ b/csv_detective/output/profile.py
@@ -4,14 +4,14 @@ from time import time
 
 import numpy as np
 import pandas as pd
-import pyarrow.parquet as pq
 
 from csv_detective.formats.float import float_casting
+from csv_detective.io.parquet import ParquetTable
 from csv_detective.utils import display_logs_depending_process_time
 
 
 def create_profile(
-    table: pd.DataFrame | pq.ParquetFile,
+    table: pd.DataFrame | ParquetTable,
     columns: dict,
     num_rows: int,
     limited_output: bool = True,

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -7,8 +7,8 @@ import pandas as pd
 from more_itertools import peekable
 
 from csv_detective.format import Format
-from csv_detective.io.parquet import ParquetTable, rugo_logical_type_to_python
 from csv_detective.io.csv import read_csv
+from csv_detective.io.parquet import ParquetTable, rugo_logical_type_to_python
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import display_logs_depending_process_time
 

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -1,14 +1,14 @@
 import logging
-import re
 from time import time
 from typing import Callable
 
 import numpy as np
 import pandas as pd
-import pyarrow.parquet as pq
 from more_itertools import peekable
 
 from csv_detective.format import Format
+from csv_detective.io.parquet import ParquetTable, rugo_logical_type_to_python
+from csv_detective.io.csv import read_csv
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import display_logs_depending_process_time
 
@@ -215,7 +215,7 @@ def test_col_chunks(
     col_values = {col: table[col].value_counts(dropna=False) for col in table.columns}
 
     # only csv files can end up here, can't chunk excel
-    chunks = pd.read_csv(
+    chunks = read_csv(
         file_path,
         dtype=str,
         encoding=analysis["encoding"],
@@ -300,46 +300,18 @@ def test_col_chunks(
     return return_table, analysis, col_values
 
 
-PYARROW_TYPE_TO_PYTHON = {
-    # using regex because of bits-differing types (e.g. int32 and int64)
-    # the "^" makes sure we don't consider the types of elements within structured objects (lists, dicts)
-    "string$": "string",  # large_string also exists
-    "^double": "float",
-    "^float": "float",
-    "^decimal": "float",
-    "^int": "int",
-    "^uint": "int",
-    "^bool": "bool",
-    "^date": "date",
-    "^struct": "json",  # dictionary
-    "^list": "json",
-    "^binary": "binary",
-    r"^timestamp\[\ws\]": "datetime_naive",
-    r"^timestamp\[\ws,": "datetime_aware",  # the rest of the field depends on the timezone
-}
-
-
-def build_known_columns(table: pq.ParquetFile):
+def build_known_columns(table: ParquetTable):
     columns = {}
-    for col in table.schema_arrow:
-        col_type = str(col.type)
-        if col_type.startswith("dictionary"):
-            # dictionaries are for columns with repeated values
-            # we need to dig deeper to get the type
-            col_type = str(col.type.value_type)
+    for col in table.schema_columns:
         try:
-            columns[col.name] = next(
-                pytype
-                for pyartype, pytype in PYARROW_TYPE_TO_PYTHON.items()
-                if re.search(pyartype, col_type)
-            )
-        except StopIteration:
-            raise ValueError(f"Unknown pyarrow type: {col.type}")
+            columns[col.name] = rugo_logical_type_to_python(col.logical_type)
+        except ValueError as exc:
+            raise ValueError(f"Unknown Rugo type: {col.logical_type}") from exc
     return columns
 
 
 def test_parquet_cols(
-    table: pq.ParquetFile,
+    table: ParquetTable,
     formats: dict[str, Format],
     analysis: dict,
     limited_output: bool,
@@ -384,7 +356,6 @@ def test_parquet_cols(
     for idx, batch in enumerate(table.iter_batches(CHUNK_SIZE * 10)):
         if verbose:
             logging.info(f"> Testing batch number {idx + 1}")
-        batch = batch.to_pandas()
         str_batch = batch.map(
             # not simply using astype(str) because lists are numpy arrays, cast as str they lose their commas
             lambda x: str(x.tolist()) if isinstance(x, np.ndarray) else str(x)

--- a/csv_detective/parsing/csv.py
+++ b/csv_detective/parsing/csv.py
@@ -4,6 +4,7 @@ from typing import TextIO
 
 import pandas as pd
 
+from csv_detective.io.csv import read_csv
 from csv_detective.utils import display_logs_depending_process_time
 
 # the number of rows for the first analysis, and the number of rows per chunk of the df iterator
@@ -28,7 +29,7 @@ def parse_csv(
         the_file.seek(0)
 
     try:
-        table = pd.read_csv(
+        table = read_csv(
             the_file,
             sep=sep,
             dtype=str,

--- a/csv_detective/parsing/load.py
+++ b/csv_detective/parsing/load.py
@@ -4,7 +4,6 @@ from io import BytesIO, StringIO
 from typing import Any
 
 import pandas as pd
-import pyarrow.parquet as pq
 import requests
 
 from csv_detective.detection.columns import detect_heading_columns, detect_trailing_columns
@@ -16,6 +15,7 @@ from csv_detective.detection.engine import (
 )
 from csv_detective.detection.headers import detect_header_position
 from csv_detective.detection.separator import detect_separator
+from csv_detective.io.parquet import ParquetTable
 from csv_detective.parsing.compression import unzip
 from csv_detective.parsing.csv import parse_csv
 from csv_detective.parsing.excel import (
@@ -35,7 +35,7 @@ def load_file(
     engine: str | None = None,
     sheet_name: str | int | None = None,
     na_values: list[str] | None = None,
-) -> tuple[pd.DataFrame | pq.ParquetFile, dict]:
+) -> tuple[pd.DataFrame | ParquetTable, dict]:
     file_name = file_path.split("/")[-1]
     if ("." not in file_name or not file_name.endswith("csv")) and engine is None and sep is None:
         # file has no extension and we don't have insights from arguments, we'll investigate how to read it

--- a/csv_detective/parsing/parquet.py
+++ b/csv_detective/parsing/parquet.py
@@ -1,31 +1,17 @@
-from io import BytesIO
 from time import time
 
-import pyarrow.parquet as pq
-import requests
-
-from csv_detective.utils import (
-    display_logs_depending_process_time,
-    is_url,
-)
+from csv_detective.io.parquet import ParquetTable, load_parquet
+from csv_detective.utils import display_logs_depending_process_time
 
 
-def load_as_parquetfile(file_path: str) -> pq.ParquetFile:
-    if is_url(file_path):
-        r = requests.get(file_path)
-        r.raise_for_status()
-        return pq.ParquetFile(BytesIO(r.content))
-    return pq.ParquetFile(file_path)
-
-
-def parse_parquet(file_path: str, verbose: bool = False) -> tuple[pq.ParquetFile, dict]:
+def parse_parquet(file_path: str, verbose: bool = False) -> tuple[ParquetTable, dict]:
     if verbose:
         start = time()
-    table = load_as_parquetfile(file_path)
+    table = load_parquet(file_path)
     analysis = {
         "engine": "parquet",
-        "header": [col.name for col in table.schema_arrow],
-        "total_lines": table.metadata.num_rows,
+        "header": table.column_names,
+        "total_lines": table.num_rows,
     }
     if verbose:
         display_logs_depending_process_time(

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -5,13 +5,14 @@ import numpy as np
 import pandas as pd
 
 from csv_detective.format import FormatsManager
+from csv_detective.io.csv import read_csv
+from csv_detective.io.parquet import load_parquet
 from csv_detective.output.utils import extract_unique_from_multicat
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
     RATIO_CATEGORICAL_VALUES,
     build_known_columns,
 )
-from csv_detective.parsing.parquet import load_as_parquetfile
 
 # VALIDATION_CHUNK_SIZE is bigger than (analysis) CHUNK_SIZE because
 # it's faster to validate so we can afford to load more rows
@@ -52,7 +53,7 @@ def validate(
     try:
         if previous_analysis.get("separator"):
             # loading the table in chunks
-            chunks = pd.read_csv(
+            chunks = read_csv(
                 file_path,
                 dtype=str,
                 sep=previous_analysis["separator"],
@@ -78,10 +79,8 @@ def validate(
                 and v is not None
             }
         elif previous_analysis.get("engine") == "parquet":
-            pf = load_as_parquetfile(file_path)
-            chunks = iter(
-                batch.to_pandas() for batch in pf.iter_batches(batch_size=VALIDATION_CHUNK_SIZE)
-            )
+            pf = load_parquet(file_path)
+            chunks = iter(pf.iter_batches(VALIDATION_CHUNK_SIZE))
             known_columns = build_known_columns(pf)
             for col_name in known_columns:
                 # checking columns and types from metadata for potential early stop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Faker>=33.0.0",
     "rstr>=3.2.2",
     "more-itertools>=10.8.0",
-    "pyarrow>=23.0.0",
+    "rugo>=0.4.18",
 ]
 requires-python = ">=3.11,<3.15"
 license = { text = "MIT" }

--- a/tests/test_io_csv.py
+++ b/tests/test_io_csv.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from csv_detective.io.csv import read_csv
+
+
+def test_read_csv_respects_skiprows_and_leading_zeros():
+    dataframe = read_csv(
+        "tests/data/a_test_file.csv",
+        sep=";",
+        skiprows=2,
+        nrows=3,
+        encoding="utf-8",
+    )
+    assert dataframe.iloc[0]["NUMCOM"] == "01001"
+
+
+def test_read_csv_chunks():
+    chunks = read_csv(
+        "tests/data/a_test_file.csv",
+        sep=";",
+        skiprows=2,
+        chunksize=100,
+        encoding="utf-8",
+    )
+    first_chunk = next(chunks)
+    assert isinstance(first_chunk, pd.DataFrame)
+    assert len(first_chunk) == 100
+
+
+def test_read_csv_unnamed_columns():
+    from io import StringIO
+
+    content = "col1,col2,\n1,2,\n3,4,"
+    dataframe = read_csv(StringIO(content), sep=",", skiprows=0)
+    assert list(dataframe.columns) == ["col1", "col2", "Unnamed: 2"]

--- a/tests/test_io_parquet.py
+++ b/tests/test_io_parquet.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from csv_detective.io.parquet import ParquetTable, load_parquet, rugo_logical_type_to_python
+
+
+def test_load_parquet_metadata():
+    table = load_parquet("tests/data/file.parquet")
+    assert isinstance(table, ParquetTable)
+    assert table.num_rows == 1000
+    assert table.column_names[0] == "inseecommune"
+
+
+def test_rugo_logical_type_mapping():
+    assert rugo_logical_type_to_python("varchar") == "string"
+    assert rugo_logical_type_to_python("array<int64>") == "json"
+    assert rugo_logical_type_to_python("timestamp[ns]") == "datetime_naive"
+
+
+def test_iter_batches_returns_dataframe():
+    table = load_parquet("tests/data/file.parquet")
+    batch = next(table.iter_batches(batch_size=100))
+    assert isinstance(batch, pd.DataFrame)
+    assert len(batch) == 100
+    assert batch.iloc[0]["inseecommune"] == "73327"

--- a/uv.lock
+++ b/uv.lock
@@ -116,11 +116,11 @@ dependencies = [
     { name = "odfpy" },
     { name = "openpyxl" },
     { name = "pandas" },
-    { name = "pyarrow" },
     { name = "python-dateutil" },
     { name = "python-magic" },
     { name = "requests" },
     { name = "rstr" },
+    { name = "rugo" },
     { name = "unidecode" },
     { name = "xlrd" },
 ]
@@ -143,11 +143,11 @@ requires-dist = [
     { name = "odfpy", specifier = ">=1.4.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=3.0.1,<4" },
-    { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "rstr", specifier = ">=3.2.2" },
+    { name = "rugo", specifier = ">=0.4.18" },
     { name = "unidecode", specifier = ">=1.3.6,<2" },
     { name = "xlrd", specifier = ">=2.0.1" },
 ]
@@ -425,56 +425,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyarrow"
-version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
-    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
-    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
-    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
-    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
-    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
-    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
-    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
-    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
-    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
-    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
-    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -747,6 +697,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/0b/8e4e0639e4cc12547f41cb771b0b44ec8225b6b6a93393176d75fe6f7d40/ruff-0.14.6-py3-none-win32.whl", hash = "sha256:00169c0c8b85396516fdd9ce3446c7ca20c2a8f90a77aa945ba6b8f2bfe99e85", size = 13013361, upload-time = "2025-11-21T14:26:08.152Z" },
     { url = "https://files.pythonhosted.org/packages/fb/02/82240553b77fd1341f80ebb3eaae43ba011c7a91b4224a9f317d8e6591af/ruff-0.14.6-py3-none-win_amd64.whl", hash = "sha256:390e6480c5e3659f8a4c8d6a0373027820419ac14fa0d2713bd8e6c3e125b8b9", size = 14432087, upload-time = "2025-11-21T14:26:10.891Z" },
     { url = "https://files.pythonhosted.org/packages/a5/1f/93f9b0fad9470e4c829a5bb678da4012f0c710d09331b860ee555216f4ea/ruff-0.14.6-py3-none-win_arm64.whl", hash = "sha256:d43c81fbeae52cfa8728d8766bbf46ee4298c888072105815b392da70ca836b2", size = 13520930, upload-time = "2025-11-21T14:26:13.951Z" },
+]
+
+[[package]]
+name = "rugo"
+version = "0.4.18"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/8c/916963062465547e9218a989fef78713157aa0cb7c00ee71b6a920d6be49/rugo-0.4.18-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:00ab897ea65e82ef3e7dc0c7e6dac2145c6f6e9d985041c6d26155f674445c0c", size = 3434100, upload-time = "2026-07-23T19:30:17.285Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/4377a3c6314b19793e2a8ff7d4e9197831fe504b03a5fecb4e18561bd4f6/rugo-0.4.18-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5207d5275f976d40ff2115a3329718aac72a036f41f4739421ea28b64db14f5d", size = 5769876, upload-time = "2026-07-23T19:30:19.113Z" },
+    { url = "https://files.pythonhosted.org/packages/71/45/229cb3a1f5e38d30869561a19f92356e4458b3d21022e7621863424eb0a0/rugo-0.4.18-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8433feaee9d8ce8775f959882314d39b1fb2a2b154231c7414185e4544ce5b33", size = 6438511, upload-time = "2026-07-23T19:30:20.896Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/1dd11631ecf295ed9e5aac7d9c7170516a043e51063468d7e6628e9c5d23/rugo-0.4.18-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:960161f719a4e722a155e678c1a82b23f960803ecd6e8e783964ad5a7093cc9c", size = 3440620, upload-time = "2026-07-23T19:30:23.22Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/c6d09cbef55c85bceb45e875985247eb3fc6a8e747f3aa85b580c29360b8/rugo-0.4.18-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db07a8a21170badc3706bf3290171131337f3ee4dba98df19dfa3812926c1015", size = 5734480, upload-time = "2026-07-23T19:30:25.201Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ab/ea193fb479af68d8ef2f3ae53563b9cc66ef944af67cb133c62c316fe7d8/rugo-0.4.18-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7f0efeb86b0ef2349b4c44683ed88618090e9905f2045eb409567beab3509cb", size = 6393039, upload-time = "2026-07-23T19:30:34.787Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/a850eb8607e1b4a632a1c047e0ec7a002e35935a4084cd7ecba7f4669732/rugo-0.4.18-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba6144d31b55b9d6133eccefc32f79ebfc675beac6485961744aafb7df34bf04", size = 3438398, upload-time = "2026-07-23T19:30:36.763Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c5/a2ce313149251f53d7ffc7f17a6e1dcb84c811453339462fa353d2948a19/rugo-0.4.18-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a49ee4fbc93fc3feec86e600a4eebd477ef8fa10e287c2947c7f4f8245f08d7b", size = 5726209, upload-time = "2026-07-23T19:30:39.301Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7e/e7758d90191e2d371791bb850c35b9c7dcb64b12b4615f36e3db748fbd54/rugo-0.4.18-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06c5f45f4fea8603fb867b448f40ee4f3f42d662ced30e718c28cc50822c2132", size = 6394022, upload-time = "2026-07-23T19:30:41.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/bd8f31df2e6341ed3b86b379946be4da642dd014d6679d3581f71e624554/rugo-0.4.18-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eaac5f4ae298c1c23a18154508866956124cfca4a8b0e254470a87816146dabe", size = 3442561, upload-time = "2026-07-23T19:30:42.985Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4a/4cdcc94de50a9c5f167fb417599c9d8a23bf53fa94730e6bdbcf8e809d11/rugo-0.4.18-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e197f18cff1d181e8c7a15e27bde8a8cfb322d769ad045b2054e66895f3659a7", size = 5737923, upload-time = "2026-07-23T19:30:44.694Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/42/ea295286954081015c14ed3f2967593552b2be8969893e32b4802b674d65/rugo-0.4.18-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1c3ca5b2b4329ef77c62d38b7ec5e16f4cc41d5937bfc9ee1aeda76dd91cd16", size = 6395517, upload-time = "2026-07-23T19:30:46.297Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use [Rugo](https://rugo.dev/#quickstart) for I/O.

benchmarks results:

```json
=== Benchmark Results ===
{
  "datetime": "2026-07-27T17:30:31Z",
  "ci": "circleci",
  "commit_id": "72b0f2a",
  "runner_class": "large",
  "runner_cpu": "36",
  "runner_memory_mb": "70803",
  "python_version": "3.14",
  "nb_rows": 500000,
  "input_file": "benchmark_input.csv",
  "scenarios": [
    {
      "test_name": "test_routine_big_file",
      "runs_seconds": [
        93.127,
        94.287,
        89.315
      ],
      "execution_time_seconds": 93.127,
      "nb_runs": 3
    },
    {
      "test_name": "test_routine_big_file_with_profile",
      "runs_seconds": [
        86.346,
        76.734,
        77.056
      ],
      "execution_time_seconds": 77.056,
      "nb_runs": 3
    }
  ]
}
=========================
```