### PR TITLE
fix: cast dd/mm/yyyy dates day-first (was silently swapping day and month)

### DIFF
--- a/csv_detective/formats/date.py
+++ b/csv_detective/formats/date.py
@@ -28,16 +28,6 @@ labels = SHARED_DATE_LABELS | {
 }
 
 
-def date_casting(val: str) -> datetime | None:
-    """For performance reasons, we try first with dateutil and fallback on dateparser"""
-    try:
-        return dateutil_parser(val)
-    except ParserError:
-        return date_parser(val)
-    except Exception:
-        return None
-
-
 threshold = 0.3
 seps = r"[\s/\-\*_\|;.,]"
 # matches JJ-MM-AAAA with any of the listed separators
@@ -55,6 +45,22 @@ string_month_pattern = (
     r"mai|juin|juillet|aout|septembre|octobre|novembre|decembre)SEP"
     r"([0-9]{2}$|(19|20)[0-9]{2}$)"
 ).replace("SEP", seps + "?")
+
+
+def date_casting(val: str) -> datetime | None:
+    """For performance reasons, we try first with dateutil and fallback on dateparser"""
+    # Note: Both parsers default to month-first, which silently swaps day and month for the
+    # values matching jjmmaaaa_pattern where both are valid months ("07/03/2024").
+    # Day-first remains the most common pattern in French date system:
+    # if this pattern is valid, then we apply it first.
+    # Other values (ISO dates especially) must keep the default behaviour.
+    dayfirst = bool(re.match(jjmmaaaa_pattern, val))
+    try:
+        return dateutil_parser(val, dayfirst=dayfirst)
+    except ParserError:
+        return date_parser(val, settings={"DATE_ORDER": "DMY"} if dayfirst else {})
+    except Exception:
+        return None
 
 
 def _is(val) -> bool:
@@ -88,6 +94,7 @@ _test_values = {
     True: [
         "1960-08-07",
         "12/02/2007",
+        "07/03/2024",
         "15 jan 1985",
         "15 décembre 1985",
         "02 05 2003",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -113,6 +113,26 @@ def test_cast(args):
         assert isinstance(cast(value, detected_type), cast_type)
 
 
+# casting has to follow jjmmaaaa_pattern, which is day-first
+@pytest.mark.parametrize(
+    "args",
+    (
+        # both components are valid months => day first
+        ("07/03/2024", _date(2024, 3, 7)),
+        ("01/02/2024", _date(2024, 2, 1)),
+        # unambiguous values are unaffected
+        ("29/11/2017", _date(2017, 11, 29)),
+        # day first is only a preference, US-style dates still parse
+        ("12/25/2024", _date(2024, 12, 25)),
+        # ISO is unaffected
+        ("2024-03-07", _date(2024, 3, 7)),
+    ),
+)
+def test_cast_date_is_day_first(args):
+    value, expected = args
+    assert cast(value, "date") == expected
+
+
 @pytest.mark.parametrize(
     "args",
     (


### PR DESCRIPTION
## Problem

`date._is()` accepts `dd/mm/yyyy` values through `jjmmaaaa_pattern`, which is day-first
by construction.

But `date_casting()` then converted those values with `dateutil.parser.parse(val)`,
falling back on `dateparser.parse(val)` - **both default to month-first**, and neither
was given a `dayfirst` / `DATE_ORDER` argument.

The casting function is used in Hydra (to be confirmed), and every value where both components are
≤ 12 was silently inverted:

```
"07/03/2024"  _is=True  ->  2024-07-03   # 7 March read as 3 July
"01/02/2024"  _is=True  ->  2024-01-02   # 1 February read as 2 January
```

The inversion is silent: no error, no warning, and the output is a perfectly valid date.

This issue has been uncovered through this [discussion](https://www.data.gouv.fr/datasets/evaluation-des-dispositifs-medicaux/discussions) on the platform.

## Proposal

Pass `dayfirst` to the parsers **only for values that match `jjmmaaaa_pattern`**  from the detection step. Because this pattern requires the second component to be 01–12 and the first to be 01–31, a matching value can only be read as DD then MM. 

`date_casting` moves below the pattern definitions so it can use `jjmmaaaa_pattern`.

**Note : Why not just `dayfirst=True` everywhere**

Tried first, and it breaks two things:

- `dateutil` applies `dayfirst` to the day/month pair regardless of position in regard to year digits, so ISO
  `2024-03-07` was parsed as 3 July.
- `DATE_ORDER: DMY` makes the `dateparser` fallback accept `12152003`, `20031512` and
  `02052003`, which `date._test_values[False]` explicitly requires to be rejected.

Scoping the flag to the pattern avoids both.

### Impact on existing data

Behaviour-changing for downstream consumers. Dates already stored by hydra for CSV resources with ambiguous `dd/mm/yyyy` values are wrong and would need reprocessing.