### PR TITLE
perf: score each column once on the whole file instead of averaging chunk scores

### DIFF
--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -15,8 +15,9 @@ from csv_detective.output.utils import (
 )
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
+    count_values,
     handle_empty_columns,
-    test_col,
+    score_columns,
     test_col_chunks,
     test_label,
     test_parquet_cols,
@@ -53,16 +54,14 @@ def detect_formats(
             table=table,
             formats=formats,
             analysis=analysis,
-            limited_output=limited_output,
             skipna=skipna,
             verbose=verbose,
         )
     elif not in_chunks:
         # table is small enough to be tested in one go
-        scores_table_fields = test_col(
-            table=table,
-            formats=formats,
-            limited_output=limited_output,
+        scores_table_fields = score_columns(
+            {col: count_values(table[col]) for col in table.columns},
+            formats,
             skipna=skipna,
             verbose=verbose,
         )
@@ -79,7 +78,6 @@ def detect_formats(
             file_path=file_path,
             analysis=analysis,
             formats=formats,
-            limited_output=limited_output,
             skipna=skipna,
             na_values=na_values,
             verbose=verbose,
@@ -99,7 +97,7 @@ def detect_formats(
     else:
         for col in col_values.keys():
             if analysis["columns_fields"][col]["format"] == "json" and all(
-                value.startswith("[") for value in col_values[col].index
+                value.startswith("[") for value in col_values[col].index.dropna()
             ):
                 unique = extract_unique_from_multicat(col_values[col].index.to_series())
                 if unique is not None:

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -40,29 +40,21 @@ def _testable_values(values: pd.Series, skipna: bool) -> pd.Series:
     return values.sort_values(ascending=False)
 
 
-def score_column(values: pd.Series, format: Format) -> float:
+def score_column(values: pd.Series, total: float, format: Format) -> float:
     """The share of the column the format reads, 0.0 if it cannot reach its own proportion.
 
     `values` counts every distinct value of the *whole* column, so the total is known up front:
     that is what lets us give up as soon as the failures put the threshold out of reach, instead
     of reading every value of every column for every format.
     """
-    total = values.sum()
-    if not total:
-        # the whole column is empty, so every format fits it; handle_empty_columns settles the
-        # case afterwards, once we know they all did
-        return 1.0
     max_failures = (1 - format.proportion) * total
-    matching = 0
     failing = 0
     for value, count in values.items():
-        if format.func(value):
-            matching += count
-        else:
+        if not format.func(value):
             failing += count
             if failing > max_failures:
                 return 0.0
-    return matching / total
+    return 1 - failing / total
 
 
 def score_columns(
@@ -70,11 +62,15 @@ def score_columns(
     formats: dict[str, Format],
     *,
     skipna: bool = True,
-    mandatory_label_skip: dict[str, set[str]] | None = None,
+    skipped_labels: dict[str, set[str]] | None = None,
     known_columns: dict[str, str] | None = None,
     verbose: bool = False,
 ) -> pd.DataFrame:
-    """Scores every column against every format, from the value counts of the whole file."""
+    """Scores every column against every format, from the value counts of the whole file.
+
+    `skipped_labels` lists, per column, the formats that are out of the running whatever the
+    values hold, so that the expensive field tests are not run on them.
+    """
     if verbose:
         start = time()
         logging.info("Scoring columns against every format")
@@ -82,22 +78,22 @@ def score_columns(
     for col, raw_values in col_values.items():
         start_col = time()
         values = _testable_values(raw_values, skipna)
-        if not values.sum():
+        total = values.sum()
+        if not total:
             # an empty column fits every format, including the ones we would otherwise skip:
             # handle_empty_columns needs to see them all agree to settle the case
             return_table[col] = 1.0
             continue
-        skipped = (mandatory_label_skip or {}).get(col, set())
+        skipped = (skipped_labels or {}).get(col, set())
+        known_label = (known_columns or {}).get(col)
         for label, format in formats.items():
-            if (known_columns or {}).get(col) == label:
+            if label == known_label:
                 # the file's own metadata already tells us this column is of that type
                 return_table.loc[label, col] = 1.0
             elif label in skipped:
-                # mandatory_label formats are zeroed out at the end if the label doesn't match,
-                # so there's no point running the expensive field tests on those columns
                 return_table.loc[label, col] = 0.0
             else:
-                return_table.loc[label, col] = score_column(values, format)
+                return_table.loc[label, col] = score_column(values, total, format)
         if verbose and time() - start_col > 3:
             display_logs_depending_process_time(
                 f"\t/!\\ Column '{col}' took too long ({round(time() - start_col, 3)}s)",
@@ -108,22 +104,6 @@ def score_columns(
             f"Done scoring columns in {round(time() - start, 3)}s", time() - start
         )
     return return_table
-
-
-def test_col(
-    table: pd.DataFrame,
-    formats: dict[str, Format],
-    *,
-    limited_output: bool = True,
-    skipna: bool = True,
-    verbose: bool = False,
-) -> pd.DataFrame:
-    return score_columns(
-        {col: count_values(table[col]) for col in table.columns},
-        formats,
-        skipna=skipna,
-        verbose=verbose,
-    )
 
 
 def test_label(columns: list[str], formats: dict[str, Format], verbose: bool = False):
@@ -153,7 +133,6 @@ def test_col_chunks(
     file_path: str,
     analysis: dict,
     formats: dict[str, Format],
-    limited_output: bool,
     skipna: bool = True,
     na_values: list[str] | None = None,
     verbose: bool = False,
@@ -199,7 +178,9 @@ def test_col_chunks(
         col_values,
         formats,
         skipna=skipna,
-        mandatory_label_skip={
+        skipped_labels={
+            # mandatory_label formats are zeroed out at the end if the label doesn't match,
+            # so there's no point running the expensive field tests on those columns
             col: {
                 fmt_label
                 for fmt_label, fmt in formats.items()
@@ -266,7 +247,6 @@ def test_parquet_cols(
     table: pq.ParquetFile,
     formats: dict[str, Format],
     analysis: dict,
-    limited_output: bool,
     skipna: bool = True,
     verbose: bool = False,
 ):
@@ -281,10 +261,16 @@ def test_parquet_cols(
     for idx, batch in enumerate(table.iter_batches(CHUNK_SIZE * 10)):
         if verbose:
             logging.info(f"> Reading batch number {idx + 1}")
-        batch = batch.to_pandas()
+        # a null in an integer column is enough to have it read as floats, and counted as
+        # "2015.0" instead of "2015", which no format expecting an integer reads: asking for
+        # objects keeps the integers, and casting settles the columns pandas typed on its own
+        batch = batch.to_pandas(integer_object_nulls=True).astype(object)
         str_batch = batch.map(
             # not simply using astype(str) because lists are numpy arrays, cast as str they lose their commas
-            lambda x: str(x.tolist()) if isinstance(x, np.ndarray) else str(x)
+            lambda x: str(x.tolist()) if isinstance(x, np.ndarray) else str(x),
+            # nulls have to stay null: cast as str they would become the value "nan", which every
+            # format is asked about and fails on, sinking the whole column
+            na_action="ignore",
         )
         row_hashes_count = row_hashes_count.add(
             pd.util.hash_pandas_object(str_batch, index=False).value_counts(),
@@ -297,11 +283,12 @@ def test_parquet_cols(
         col_values,
         formats,
         skipna=skipna,
-        mandatory_label_skip={
+        skipped_labels={
+            # the metadata gives the type away, so only the formats of that type can apply, and
+            # mandatory_label formats are zeroed out at the end if the label doesn't match anyway
             col: {
                 fmt_label
                 for fmt_label, fmt in formats.items()
-                # the metadata gives the type away, so only the formats of that type can apply
                 if fmt.python_type != pytype
                 or (fmt.mandatory_label and fmt.is_valid_label(col) == 0)
             }

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -13,7 +13,8 @@ from csv_detective.utils import display_logs_depending_process_time
 # above this threshold, a column is not considered categorical
 MAX_NUMBER_CATEGORICAL_VALUES = 25
 RATIO_CATEGORICAL_VALUES = 0.05
-# how many chunks are concatenated before their values are counted
+# the file is re-read by batches of that many chunks: each add() realigns the running index, which
+# holds every distinct value seen so far, so counting once per chunk would dominate the reading
 CHUNKS_PER_BATCH = 10
 
 
@@ -162,10 +163,10 @@ def test_col_chunks(
         logging.info("Reading the file to count the values of each column")
 
     # hashing rows to get nb_duplicates
-    row_hashes_count = pd.util.hash_pandas_object(table, index=False).value_counts()
+    row_hashes_count = pd.Series()
     # getting values for profile to read the file only once
-    col_values = {col: count_values(table[col]) for col in table.columns}
-    analysis["total_lines"] = len(table)
+    col_values = {col: pd.Series() for col in table.columns}
+    analysis["total_lines"] = 0
 
     # only csv files can end up here, can't chunk excel
     chunks = pd.read_csv(
@@ -175,36 +176,19 @@ def test_col_chunks(
         sep=analysis["separator"],
         skiprows=analysis["header_row_idx"],
         compression=analysis.get("compression"),
-        chunksize=CHUNK_SIZE,
+        chunksize=CHUNK_SIZE * CHUNKS_PER_BATCH,
         na_values=na_values,
     )
-
-    def add_to_counts(rows: pd.DataFrame) -> None:
-        nonlocal row_hashes_count
-        analysis["total_lines"] += len(rows)
+    for idx, batch in enumerate(chunks):
+        if verbose:
+            logging.info(f"> Reading batch number {idx + 1}")
+        analysis["total_lines"] += len(batch)
         row_hashes_count = row_hashes_count.add(
-            pd.util.hash_pandas_object(rows, index=False).value_counts(),
+            pd.util.hash_pandas_object(batch, index=False).value_counts(),
             fill_value=0,
         )
-        for col in rows.columns:
-            col_values[col] = col_values[col].add(count_values(rows[col]), fill_value=0)
-
-    # chunks are grouped before being counted: each add() realigns the running index, which holds
-    # every distinct value seen so far, so doing it once per chunk would dominate the reading
-    batch: list[pd.DataFrame] = []
-    for idx, chunk in enumerate(chunks):
-        if idx == 0:
-            # we have read this one already, it is the sample we were given
-            continue
-        batch.append(chunk)
-        if len(batch) < CHUNKS_PER_BATCH:
-            continue
-        if verbose:
-            logging.info(f"> Reading up to chunk number {idx}")
-        add_to_counts(pd.concat(batch, ignore_index=True))
-        batch = []
-    if batch:
-        add_to_counts(pd.concat(batch, ignore_index=True))
+        for col in batch.columns:
+            col_values[col] = col_values[col].add(count_values(batch[col]), fill_value=0)
 
     # Formats are scored once, here, on the counts of the whole file rather than chunk by chunk.
     # Averaging chunk scores gave a short chunk the same weight as a long one, and no format could

--- a/csv_detective/parsing/columns.py
+++ b/csv_detective/parsing/columns.py
@@ -1,12 +1,10 @@
 import logging
 import re
 from time import time
-from typing import Callable
 
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
-from more_itertools import peekable
 
 from csv_detective.format import Format
 from csv_detective.parsing.csv import CHUNK_SIZE
@@ -15,6 +13,8 @@ from csv_detective.utils import display_logs_depending_process_time
 # above this threshold, a column is not considered categorical
 MAX_NUMBER_CATEGORICAL_VALUES = 25
 RATIO_CATEGORICAL_VALUES = 0.05
+# how many chunks are concatenated before their values are counted
+CHUNKS_PER_BATCH = 10
 
 
 def handle_empty_columns(return_table: pd.DataFrame):
@@ -24,95 +24,105 @@ def handle_empty_columns(return_table: pd.DataFrame):
             return_table[col] = 0.0
 
 
-def test_col_val(
-    serie: pd.Series,
-    format: Format,
+def count_values(serie: pd.Series) -> pd.Series:
+    """How many times the column holds each of its distinct values."""
+    return serie.value_counts(dropna=False)
+
+
+def _testable_values(values: pd.Series, skipna: bool) -> pd.Series:
+    # NaNs are not values to test: with skipna they don't count at all, and without they are
+    # failures, which is what any format would return on them anyway
+    if skipna:
+        values = values[values.index.notna()]
+    # most frequent first, so that a format that does not fit the column runs out of its failure
+    # budget in as few tests as possible
+    return values.sort_values(ascending=False)
+
+
+def score_column(values: pd.Series, format: Format) -> float:
+    """The share of the column the format reads, 0.0 if it cannot reach its own proportion.
+
+    `values` counts every distinct value of the *whole* column, so the total is known up front:
+    that is what lets us give up as soon as the failures put the threshold out of reach, instead
+    of reading every value of every column for every format.
+    """
+    total = values.sum()
+    if not total:
+        # the whole column is empty, so every format fits it; handle_empty_columns settles the
+        # case afterwards, once we know they all did
+        return 1.0
+    max_failures = (1 - format.proportion) * total
+    matching = 0
+    failing = 0
+    for value, count in values.items():
+        if format.func(value):
+            matching += count
+        else:
+            failing += count
+            if failing > max_failures:
+                return 0.0
+    return matching / total
+
+
+def score_columns(
+    col_values: dict[str, pd.Series],
+    formats: dict[str, Format],
     *,
     skipna: bool = True,
-    limited_output: bool = False,
-    zero_if_too_low: bool = True,
+    mandatory_label_skip: dict[str, set[str]] | None = None,
+    known_columns: dict[str, str] | None = None,
     verbose: bool = False,
-) -> float:
-    """Tests values of the serie using test_func.
-         - skipna : if True indicates that NaNs are considered True
-    for the serie to be detected as a certain format
-    """
+) -> pd.DataFrame:
+    """Scores every column against every format, from the value counts of the whole file."""
     if verbose:
         start = time()
-
-    # TODO : change for a cleaner method and only test columns in modules labels
-    def apply_test_func(serie: pd.Series, test_func: Callable, _range: int):
-        return serie.sample(n=_range).apply(test_func)
-
-    try:
-        if skipna:
-            serie = serie.dropna()
-        ser_len = len(serie)
-        if ser_len == 0:
-            # being here means the whole column is NaN, so if skipna it's a pass
-            return 1.0 if skipna else 0.0
-        if not limited_output or format.proportion < 1:
-            # we want or have to go through the whole column to have the proportion
-            value_counts = serie.value_counts()
-            unique_results = value_counts.index.to_series().apply(format.func)
-            result: float = (unique_results * value_counts.values).sum() / ser_len
-            return 0.0 if result < format.proportion and zero_if_too_low else result
-        else:
-            # the whole column has to be valid so we have early stops (1 then 5 rows)
-            # to not waste time if directly unsuccessful
-            for _range in [
-                min(1, ser_len),
-                min(5, ser_len),
-            ]:
-                if not all(apply_test_func(serie, format.func, _range)):
-                    return 0.0
-            return float(all(format.func(v) for v in serie.unique()))
-    finally:
-        if verbose and time() - start > 3:
+        logging.info("Scoring columns against every format")
+    return_table = pd.DataFrame(columns=list(col_values.keys()), index=list(formats.keys()))
+    for col, raw_values in col_values.items():
+        start_col = time()
+        values = _testable_values(raw_values, skipna)
+        if not values.sum():
+            # an empty column fits every format, including the ones we would otherwise skip:
+            # handle_empty_columns needs to see them all agree to settle the case
+            return_table[col] = 1.0
+            continue
+        skipped = (mandatory_label_skip or {}).get(col, set())
+        for label, format in formats.items():
+            if (known_columns or {}).get(col) == label:
+                # the file's own metadata already tells us this column is of that type
+                return_table.loc[label, col] = 1.0
+            elif label in skipped:
+                # mandatory_label formats are zeroed out at the end if the label doesn't match,
+                # so there's no point running the expensive field tests on those columns
+                return_table.loc[label, col] = 0.0
+            else:
+                return_table.loc[label, col] = score_column(values, format)
+        if verbose and time() - start_col > 3:
             display_logs_depending_process_time(
-                f"\t/!\\ Column '{serie.name}' took too long ({round(time() - start, 3)}s)",
-                time() - start,
+                f"\t/!\\ Column '{col}' took too long ({round(time() - start_col, 3)}s)",
+                time() - start_col,
             )
+    if verbose:
+        display_logs_depending_process_time(
+            f"Done scoring columns in {round(time() - start, 3)}s", time() - start
+        )
+    return return_table
 
 
 def test_col(
     table: pd.DataFrame,
     formats: dict[str, Format],
     *,
-    limited_output: bool,
+    limited_output: bool = True,
     skipna: bool = True,
-    zero_if_too_low: bool = True,
     verbose: bool = False,
-):
-    if verbose:
-        start = time()
-        logging.info("Testing columns to get formats")
-    return_table = pd.DataFrame(columns=table.columns)
-    for idx, (label, format) in enumerate(formats.items()):
-        if verbose:
-            start_type = time()
-            logging.info(f"\t- Starting with format '{label}'")
-        # improvement lead : put the longest tests behind and make them only if previous tests not satisfactory
-        # => the following needs to change, "apply" means all columns are tested for one type at once
-        for col in table.columns:
-            return_table.loc[label, col] = test_col_val(
-                table[col],
-                format,
-                skipna=skipna,
-                zero_if_too_low=zero_if_too_low,
-                limited_output=limited_output,
-                verbose=verbose,
-            )
-        if verbose:
-            display_logs_depending_process_time(
-                f'\t> Done with format "{label}" in {round(time() - start_type, 3)}s ({idx + 1}/{len(formats)})',
-                time() - start_type,
-            )
-    if verbose:
-        display_logs_depending_process_time(
-            f"Done testing columns in {round(time() - start, 3)}s", time() - start
-        )
-    return return_table
+) -> pd.DataFrame:
+    return score_columns(
+        {col: count_values(table[col]) for col in table.columns},
+        formats,
+        skipna=skipna,
+        verbose=verbose,
+    )
 
 
 def test_label(columns: list[str], formats: dict[str, Format], verbose: bool = False):
@@ -137,41 +147,6 @@ def test_label(columns: list[str], formats: dict[str, Format], verbose: bool = F
     return return_table
 
 
-def _build_remaining_tests_per_col(
-    return_table: pd.DataFrame,
-    mandatory_label_skip: dict[str, set[str]],
-    known_columns: dict[str, str] = {},
-) -> dict[str, list[str]]:
-    # returns a dict with the table's columns as keys and the list of remaining format labels to apply
-    return {
-        col: [
-            fmt_label
-            for fmt_label in return_table.index
-            # for parquet we know for sure some column types
-            if known_columns.get(col) != fmt_label
-            and return_table.loc[fmt_label, col] > 0
-            and fmt_label not in mandatory_label_skip.get(col, set())
-        ]
-        for col in return_table.columns
-    }
-
-
-def _apply_proportion_thresholds(
-    return_table: pd.DataFrame,
-    formats: dict[str, Format],
-) -> None:
-    """Zero scores still below format.proportion after full-file aggregation.
-
-    Chunk scoring may keep fractional scores (zero_if_too_low=False) so formats
-    are not eliminated mid-file; the global proportion requirement is enforced here.
-    """
-    for label, fmt in formats.items():
-        if label not in return_table.index:
-            continue
-        below = return_table.loc[label] < fmt.proportion
-        return_table.loc[label, below] = 0.0
-
-
 def test_col_chunks(
     table: pd.DataFrame,
     file_path: str,
@@ -184,35 +159,13 @@ def test_col_chunks(
 ) -> tuple[pd.DataFrame, dict, dict[str, pd.Series]]:
     if verbose:
         start = time()
-        logging.info("Testing columns to get formats on chunks")
-
-    # analysing the sample to get a first guess
-    return_table = test_col(
-        table,
-        formats,
-        limited_output=limited_output,
-        zero_if_too_low=False,  # we don't know the valid/invalid repartition of the values in the whole table
-        skipna=skipna,
-        verbose=verbose,
-    )
-    # mandatory_label formats are zeroed out at the end if the label doesn't match,
-    # so there's no point running the expensive field tests on those columns
-    mandatory_label_skip: dict[str, set[str]] = {
-        col: {
-            fmt_label
-            for fmt_label, fmt in formats.items()
-            if fmt.mandatory_label and fmt.is_valid_label(col) == 0
-        }
-        for col in table.columns
-    }
-    handle_empty_columns(return_table)
-    empty_cols = {col for col in table.columns if table[col].dropna().empty}
-    remaining_tests_per_col = _build_remaining_tests_per_col(return_table, mandatory_label_skip)
+        logging.info("Reading the file to count the values of each column")
 
     # hashing rows to get nb_duplicates
     row_hashes_count = pd.util.hash_pandas_object(table, index=False).value_counts()
     # getting values for profile to read the file only once
-    col_values = {col: table[col].value_counts(dropna=False) for col in table.columns}
+    col_values = {col: count_values(table[col]) for col in table.columns}
+    analysis["total_lines"] = len(table)
 
     # only csv files can end up here, can't chunk excel
     chunks = pd.read_csv(
@@ -225,65 +178,53 @@ def test_col_chunks(
         chunksize=CHUNK_SIZE,
         na_values=na_values,
     )
-    analysis["total_lines"] = CHUNK_SIZE
-    batch, batch_number = [], 1
-    iterator = peekable(enumerate(chunks))
-    while iterator:
-        idx, chunk = next(iterator)
-        if idx == 0:
-            # we have read and analysed the first chunk already
-            continue
-        if len(batch) < 10:
-            # it's too slow to process chunks directly, but we want to keep the first analysis
-            # on a "small" chunk, so partial analyses are done on batches of chunks
-            batch.append(chunk)
-            # we don't know when the chunks end, and doing one additionnal step
-            # for the final batch is ugly
-            try:
-                iterator.peek()
-                continue
-            except StopIteration:
-                pass
-        if verbose:
-            logging.info(f"> Testing batch number {batch_number}")
-        batch = pd.concat(batch, ignore_index=True)
-        # we can't early stop because we need the infos of all chunks for some fields
-        # and some empty-for-now columns may actually not be
-        analysis["total_lines"] += len(batch)
+
+    def add_to_counts(rows: pd.DataFrame) -> None:
+        nonlocal row_hashes_count
+        analysis["total_lines"] += len(rows)
         row_hashes_count = row_hashes_count.add(
-            pd.util.hash_pandas_object(batch, index=False).value_counts(),
+            pd.util.hash_pandas_object(rows, index=False).value_counts(),
             fill_value=0,
         )
-        for col in batch.columns:
-            col_values[col] = col_values[col].add(
-                batch[col].value_counts(dropna=False),
-                fill_value=0,
-            )
-        for col in list(empty_cols):
-            if not batch[col].dropna().empty:
-                empty_cols.discard(col)
-                remaining_tests_per_col[col] = [
-                    fmt_label
-                    for fmt_label in formats.keys()
-                    if fmt_label not in mandatory_label_skip.get(col, set())
-                ]
-        for col, fmt_labels in remaining_tests_per_col.items():
-            # testing each column with the tests that are still competing
-            # after previous batchs analyses
-            for label in fmt_labels:
-                batch_col_test = test_col_val(
-                    batch[col],
-                    formats[label],
-                    limited_output=limited_output,
-                    zero_if_too_low=False,
-                    skipna=skipna,
-                )
-                return_table.loc[label, col] = (
-                    # updating the score with weighted average
-                    (return_table.loc[label, col] * idx + batch_col_test) / (idx + 1)
-                )
-        remaining_tests_per_col = _build_remaining_tests_per_col(return_table, mandatory_label_skip)
-        batch, batch_number = [], batch_number + 1
+        for col in rows.columns:
+            col_values[col] = col_values[col].add(count_values(rows[col]), fill_value=0)
+
+    # chunks are grouped before being counted: each add() realigns the running index, which holds
+    # every distinct value seen so far, so doing it once per chunk would dominate the reading
+    batch: list[pd.DataFrame] = []
+    for idx, chunk in enumerate(chunks):
+        if idx == 0:
+            # we have read this one already, it is the sample we were given
+            continue
+        batch.append(chunk)
+        if len(batch) < CHUNKS_PER_BATCH:
+            continue
+        if verbose:
+            logging.info(f"> Reading up to chunk number {idx}")
+        add_to_counts(pd.concat(batch, ignore_index=True))
+        batch = []
+    if batch:
+        add_to_counts(pd.concat(batch, ignore_index=True))
+
+    # Formats are scored once, here, on the counts of the whole file rather than chunk by chunk.
+    # Averaging chunk scores gave a short chunk the same weight as a long one, and no format could
+    # ever be ruled out mid-file since the batches left could always bring it back up. With the
+    # totals in hand the score is exact, and a format is dropped as soon as it has failed on more
+    # values than its proportion allows.
+    return_table = score_columns(
+        col_values,
+        formats,
+        skipna=skipna,
+        mandatory_label_skip={
+            col: {
+                fmt_label
+                for fmt_label, fmt in formats.items()
+                if fmt.mandatory_label and fmt.is_valid_label(col) == 0
+            }
+            for col in table.columns
+        },
+        verbose=verbose,
+    )
     analysis["nb_duplicates"] = sum(row_hashes_count > 1)
     analysis["categorical"] = [
         col
@@ -291,7 +232,6 @@ def test_col_chunks(
         if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES
         or (len(values) / sum(values)) <= RATIO_CATEGORICAL_VALUES
     ]
-    _apply_proportion_thresholds(return_table, formats)
     handle_empty_columns(return_table)
     if verbose:
         display_logs_depending_process_time(
@@ -351,39 +291,12 @@ def test_parquet_cols(
         logging.info("Testing columns to get formats on chunks")
 
     columns = build_known_columns(table)
-    mandatory_label_skip: dict[str, set[str]] = {
-        col: {
-            fmt_label
-            for fmt_label, fmt in formats.items()
-            if fmt.mandatory_label and fmt.is_valid_label(col) == 0
-        }
-        for col in columns.keys()
-    }
-    remaining_tests_per_col = {
-        col: {
-            fmt_label
-            for fmt_label, fmt in formats.items()
-            # keeping formats that have the valid python type
-            if fmt.python_type == pytype
-            # except if the column label doesn't fit
-            and fmt_label not in mandatory_label_skip.get(col, set())
-            # we already know pure types are valid, only formats remain
-            and fmt_label != pytype
-        }
-        for col, pytype in columns.items()
-    }
-    return_table = pd.DataFrame(columns=list(columns.keys()), index=list(formats.keys()))
-    for col, pytype in columns.items():
-        if pytype != "string":
-            # setting types that we know are 100% valid from metadata
-            return_table.loc[pytype, col] = 1
-
     row_hashes_count = pd.Series()
     col_values = {col: pd.Series() for col in columns.keys()}
     # we keep the same chunk size as for csv
     for idx, batch in enumerate(table.iter_batches(CHUNK_SIZE * 10)):
         if verbose:
-            logging.info(f"> Testing batch number {idx + 1}")
+            logging.info(f"> Reading batch number {idx + 1}")
         batch = batch.to_pandas()
         str_batch = batch.map(
             # not simply using astype(str) because lists are numpy arrays, cast as str they lose their commas
@@ -394,36 +307,25 @@ def test_parquet_cols(
             fill_value=0,
         )
         for col in batch.columns:
-            col_values[col] = col_values[col].add(
-                str_batch[col].value_counts(dropna=False),
-                fill_value=0,
-            )
-        if not any(remaining_tests for remaining_tests in remaining_tests_per_col.values()):
-            # no more potential tests to do on any column, early stop
-            break
-        for col, fmt_labels in remaining_tests_per_col.items():
-            # testing each column with the tests that are still competing
-            # after previous batchs analyses
-            for label in fmt_labels:
-                batch_col_test = test_col_val(
-                    batch[col],
-                    formats[label],
-                    limited_output=limited_output,
-                    skipna=skipna,
-                )
-                return_table.loc[label, col] = (
-                    # if this batch's column tested 0 then test fails overall
-                    0
-                    if batch_col_test == 0
-                    # set the first score
-                    else batch_col_test
-                    if pd.isna(return_table.loc[label, col])
-                    # otherwise updating the score with weighted average
-                    else ((return_table.loc[label, col] * idx + batch_col_test) / (idx + 1))
-                )
-        remaining_tests_per_col = _build_remaining_tests_per_col(
-            return_table, mandatory_label_skip, known_columns=columns
-        )
+            col_values[col] = col_values[col].add(count_values(str_batch[col]), fill_value=0)
+
+    return_table = score_columns(
+        col_values,
+        formats,
+        skipna=skipna,
+        mandatory_label_skip={
+            col: {
+                fmt_label
+                for fmt_label, fmt in formats.items()
+                # the metadata gives the type away, so only the formats of that type can apply
+                if fmt.python_type != pytype
+                or (fmt.mandatory_label and fmt.is_valid_label(col) == 0)
+            }
+            for col, pytype in columns.items()
+        },
+        known_columns=columns,
+        verbose=verbose,
+    )
     analysis["nb_duplicates"] = sum(row_hashes_count > 1)
     analysis["categorical"] = [
         col for col, values in col_values.items() if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "frformat==0.5.0",
     "Faker>=33.0.0",
     "rstr>=3.2.2",
-    "more-itertools>=10.8.0",
     "pyarrow>=23.0.0",
 ]
 requires-python = ">=3.11,<3.15"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -14,7 +14,7 @@ from csv_detective.format import FormatsManager
 from csv_detective.formats.float import float_casting
 from csv_detective.output.dataframe import cast
 from csv_detective.output.utils import prepare_output_dict
-from csv_detective.parsing.columns import test_col as col_test  # to prevent pytest from testing it
+from csv_detective.parsing.columns import count_values, score_columns
 
 fmtm = FormatsManager()
 
@@ -167,7 +167,9 @@ def test_all_proportion_1():
         }
     )
     # testing columns for all formats
-    returned_table = col_test(table, fmtm.formats, limited_output=True)
+    returned_table = score_columns(
+        {col: count_values(table[col]) for col in table.columns}, fmtm.formats
+    )
     # the analysis should have found no match on any format
     assert all(returned_table[col].sum() == 0 for col in table.columns)
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -107,10 +107,12 @@ def test_a_tolerant_format_spends_its_whole_budget_before_giving_up(tmp_path):
     # with half the values allowed to fail, one invalid value is not enough to rule the format
     # out, so the valid ones behind it still have to be read
     values = ["not a date"] * 100 + ["01/01/2024"] * 110
-    _, tested = _run_counting_date_tests(
+    analysis, tested = _run_counting_date_tests(
         _chunked_file(tmp_path, values),
         custom_proportions={"date": 0.5},
     )
+    # the first chunk holds nothing but invalid values, yet the format is still the file's
+    assert analysis["columns"]["date"]["format"] == "date"
     assert sorted(tested) == ["01/01/2024", "not a date"]
 
 
@@ -129,6 +131,21 @@ def test_total_lines_counts_the_file_not_the_analysed_sample(tmp_path):
             save_results=False,
         )
     assert analysis["total_lines"] == len(values)
+
+
+def test_parquet_nulls_are_not_values_to_test(tmp_path):
+    # a null is not a value the format has to read: stringified it would become "nan", which no
+    # format reads, and a single one of them would rule every format out of the column
+    file_path = tmp_path / "with_nulls.parquet"
+    pd.DataFrame(
+        {
+            "latitude": [43.2872, None, -22.61],
+            "annee": pd.array([2015, None, 2016], dtype="Int64"),
+        }
+    ).to_parquet(file_path)
+    analysis = routine(file_path=str(file_path), num_rows=-1, save_results=False)
+    assert analysis["columns"]["latitude"]["format"] == "latitude_wgs"
+    assert analysis["columns"]["annee"]["format"] == "year"
 
 
 def test_profile_output_on_file():

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -114,6 +114,23 @@ def test_a_tolerant_format_spends_its_whole_budget_before_giving_up(tmp_path):
     assert sorted(tested) == ["01/01/2024", "not a date"]
 
 
+def test_total_lines_counts_the_file_not_the_analysed_sample(tmp_path):
+    # with num_rows > 0 the analysed table is a sample of the first chunk, so counting from it
+    # would report the sample size in place of the rows it stands for
+    values = [f"{day:02d}/01/2024" for day in range(1, 26)]
+    with (
+        patch("csv_detective.parsing.csv.CHUNK_SIZE", 10),
+        patch("csv_detective.parsing.columns.CHUNK_SIZE", 10),
+    ):
+        analysis = routine(
+            file_path=str(_chunked_file(tmp_path, values)),
+            num_rows=5,
+            output_profile=False,
+            save_results=False,
+        )
+    assert analysis["total_lines"] == len(values)
+
+
 def test_profile_output_on_file():
     output = routine(
         file_path="tests/data/a_test_file.csv",

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -7,6 +7,7 @@ import pytest
 import responses
 
 from csv_detective import routine
+from csv_detective.formats import date as date_format
 from csv_detective.output.profile import create_profile
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import sanitize_for_json
@@ -59,6 +60,58 @@ def test_columns_output_on_file(chunk_size):
         assert output["columns"]["STRUCTURED_INFO"]["format"] == "json"
         assert output["columns"]["GEO_INFO"]["python_type"] == "json"
         assert output["columns"]["GEO_INFO"]["format"] == "geojson"
+
+
+def _chunked_file(tmp_path, values):
+    file_path = tmp_path / "dates.csv"
+    file_path.write_text("date\n" + "".join(f"{value}\n" for value in values))
+    return file_path
+
+
+def _run_counting_date_tests(file_path, **kwargs):
+    """Runs an analysis over 21 chunks, recording every value the date format was asked about."""
+    tested = []
+    real_is = date_format._is
+
+    def counting_is(val):
+        tested.append(val)
+        return real_is(val)
+
+    with (
+        patch("csv_detective.parsing.csv.CHUNK_SIZE", 10),
+        patch("csv_detective.parsing.columns.CHUNK_SIZE", 10),
+        patch.object(date_format, "_is", counting_is),
+    ):
+        analysis = routine(file_path=str(file_path), num_rows=-1, save_results=False, **kwargs)
+    return analysis, tested
+
+
+def test_a_value_is_only_ever_tested_once_per_format(tmp_path):
+    # scoring happens once on the counts of the whole file, so a value repeated across chunks
+    # costs one test, not one per chunk it appears in
+    values = (["01/01/2024"] * 100 + ["02/02/2024"] * 110)[:210]
+    analysis, tested = _run_counting_date_tests(_chunked_file(tmp_path, values))
+    assert analysis["columns"]["date"]["format"] == "date"
+    assert sorted(tested) == ["01/01/2024", "02/02/2024"]
+
+
+def test_a_format_gives_up_once_it_has_failed_beyond_its_tolerance(tmp_path):
+    # date reads every value or none, so its budget is zero failures: the first value it cannot
+    # read settles the column, and the ones behind it are never looked at
+    values = ["not a date"] * 200 + ["01/01/2024"] * 10
+    _, tested = _run_counting_date_tests(_chunked_file(tmp_path, values))
+    assert tested == ["not a date"], "the format kept reading values after busting its budget"
+
+
+def test_a_tolerant_format_spends_its_whole_budget_before_giving_up(tmp_path):
+    # with half the values allowed to fail, one invalid value is not enough to rule the format
+    # out, so the valid ones behind it still have to be read
+    values = ["not a date"] * 100 + ["01/01/2024"] * 110
+    _, tested = _run_counting_date_tests(
+        _chunked_file(tmp_path, values),
+        custom_proportions={"date": 0.5},
+    )
+    assert sorted(tested) == ["01/01/2024", "not a date"]
 
 
 def test_profile_output_on_file():

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,6 @@ dependencies = [
     { name = "dateparser" },
     { name = "faker" },
     { name = "frformat" },
-    { name = "more-itertools" },
     { name = "odfpy" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -139,7 +138,6 @@ requires-dist = [
     { name = "dateparser", specifier = ">=1.2.0,<2" },
     { name = "faker", specifier = ">=33.0.0" },
     { name = "frformat", specifier = "==0.5.0" },
-    { name = "more-itertools", specifier = ">=10.8.0" },
     { name = "odfpy", specifier = ">=1.4.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=3.0.1,<4" },
@@ -233,15 +231,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
detection went from 46.5s to 107.6s on `joconde.csv` between 0.12.0 and main

#249 removed every way a format could be dropped before the end of the file (the early stop, the zeroing on a failed batch, `zero_if_too_low`), so `adresse` (proportion 0.55), `commune` and `code_postal` are tested against every value of every column now. On a profile of joconde, `adresse._is` alone is 57s over 4.2M calls.

We can't just put it back: while the file is still being read, a format below its threshold can climb back up, that's what #249 fixed. So we read first and score once at the end, from the `col_values` we already accumulate for the profile. The total is known by then, so giving up is exact: as soon as a format has failed on more than `(1 - proportion) * total` values, it's out.

| joconde.csv | detection |
|---|---|
| main | 107.6s |
| this branch | 68.1s |

Not the 46.5s of 0.12.0, but 0.12.0 stopped reading at 910 000 rows out of 992 809 and dropped formats on the first chunk alone, which is what gave the truncated `total_lines` and the missed `commune`/`code_postal` on ValeursFoncieres.

Some scores change since they were an average of per-batch scores, unweighted by batch length (a 20 rows batch counted as much as a 100 000 one). Same divergences as the ones listed in #248, worth a look on your side.

`test_col_val`, `_build_remaining_tests_per_col`, `_apply_proportion_thresholds` and `zero_if_too_low` are gone, they only existed to score as we go. #249 had no tests so I added three on the new behaviour.
