### PR TITLE
fix: json missing values

### DIFF
--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -89,7 +89,7 @@ def detect_formats(
     if col_values is None:
         for col in table.columns:
             if analysis["columns_fields"][col]["format"] == "json" and all(
-                value.startswith("[") for value in table[col]
+                value.startswith("[") for value in table[col].dropna()
             ):
                 unique = extract_unique_from_multicat(table[col])
                 if unique is not None:
@@ -99,7 +99,7 @@ def detect_formats(
     else:
         for col in col_values.keys():
             if analysis["columns_fields"][col]["format"] == "json" and all(
-                value.startswith("[") for value in col_values[col].index
+                value.startswith("[") for value in col_values[col].index.dropna()
             ):
                 unique = extract_unique_from_multicat(col_values[col].index.to_series())
                 if unique is not None:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -621,6 +621,39 @@ def test_unique_values_output(nb_rows, mocked_responses):
     assert analysis["unique_values"]["json_cat"] == [1, 2, 3]
 
 
+@pytest.mark.parametrize(
+    "nb_rows",
+    (CHUNK_SIZE // 10, CHUNK_SIZE + 1),
+)
+def test_unique_values_json_with_missing_values(nb_rows):
+    """JSON-format columns with empty cells (NaN) should not crash and be in unique_values"""
+    json_values = ['["a"]', '["b"]', '["c"]', ""]
+    csv_content = "json_col;id\n"
+    for k in range(nb_rows):
+        csv_content += f"{json_values[k % len(json_values)]};{k}\n"
+    with NamedTemporaryFile(
+        "w",
+        suffix=".csv",
+        delete=False,
+    ) as f:
+        f.write(csv_content)
+        tmp_path = f.name
+    try:
+        analysis = routine(
+            file_path=tmp_path,
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
+    finally:
+        import os
+
+        os.unlink(tmp_path)
+    assert analysis["columns"]["json_col"]["python_type"] == "json"
+    assert isinstance(analysis.get("unique_values"), dict)
+    assert analysis["unique_values"]["json_col"] == ["a", "b", "c"]
+
+
 def test_parquet_file_analysis():
     pq_path = "tests/data/file.parquet"
     analysis, chunks = routine(


### PR DESCRIPTION
Following https://github.com/datagouv/csv-detective/pull/250, fix csv-detective on json columns with NaN values during multicat detection.

[Example resource](https://www.data.gouv.fr/datasets/base-des-lieux-culturels-ouverts?resource_id=4bd1a20e-4dfd-40ff-bd4d-c714f7085de8): `csv_detective:'float' object has no attribute 'startswith'`.