### PR TITLE
fix: json missing values in validate

### DIFF
--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -244,7 +244,7 @@ def validate(
     analysis["unique_values"] = {}
     for col in col_values.keys():
         if previous_analysis["columns"][col]["format"] == "json" and all(
-            value.startswith("[") for value in col_values[col].index
+            value.startswith("[") for value in col_values[col].index.dropna()
         ):
             unique = extract_unique_from_multicat(col_values[col].index.to_series())
             if unique is not None:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -10,6 +10,7 @@ from csv_detective import routine
 from csv_detective.output.profile import create_profile
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import sanitize_for_json
+from csv_detective.validate import validate
 
 
 @pytest.fixture
@@ -651,6 +652,39 @@ def test_unique_values_json_with_missing_values(nb_rows):
         os.unlink(tmp_path)
     assert analysis["columns"]["json_col"]["python_type"] == "json"
     assert isinstance(analysis.get("unique_values"), dict)
+    assert analysis["unique_values"]["json_col"] == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize(
+    "nb_rows",
+    (CHUNK_SIZE // 10, CHUNK_SIZE + 1),
+)
+def test_validate_json_column_with_missing_values(nb_rows):
+    """JSON-format column with empty cells (NaN) must not crash validate."""
+    json_values = ['["a"]', '["b"]', '["c"]', ""]
+    csv_content = "json_col;id\n"
+    for k in range(nb_rows):
+        csv_content += f"{json_values[k % len(json_values)]};{k}\n"
+    with NamedTemporaryFile(
+        "w",
+        suffix=".csv",
+        delete=False,
+    ) as f:
+        f.write(csv_content)
+        tmp_path = f.name
+    try:
+        analysis = routine(
+            file_path=tmp_path,
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
+        is_valid, _, _ = validate(tmp_path, analysis)
+    finally:
+        import os
+
+        os.unlink(tmp_path)
+    assert is_valid
     assert analysis["unique_values"]["json_col"] == ["a", "b", "c"]
 
 


### PR DESCRIPTION
Following https://github.com/datagouv/csv-detective/pull/272

I guess it would benefit a refactor to prevent code duplication between `detect_formats` and `validate`.