### PR TITLE
refactor: dedup code between detect_format and validate

### DIFF
--- a/csv_detective/detection/formats.py
+++ b/csv_detective/detection/formats.py
@@ -10,6 +10,7 @@ from csv_detective.detection.variables import (
 )
 from csv_detective.format import Format, FormatsManager
 from csv_detective.output.utils import (
+    build_unique_values,
     extract_unique_from_multicat,
     prepare_output_dict,
 )
@@ -97,15 +98,7 @@ def detect_formats(
             elif table[col].nunique() <= MAX_NUMBER_CATEGORICAL_VALUES:
                 analysis["unique_values"][col] = list(table[col].dropna().unique())
     else:
-        for col in col_values.keys():
-            if analysis["columns_fields"][col]["format"] == "json" and all(
-                value.startswith("[") for value in col_values[col].index.dropna()
-            ):
-                unique = extract_unique_from_multicat(col_values[col].index.to_series())
-                if unique is not None:
-                    analysis["unique_values"][col] = unique
-            elif len(col_values[col]) <= MAX_NUMBER_CATEGORICAL_VALUES:
-                analysis["unique_values"][col] = list(col_values[col].index.dropna())
+        analysis["unique_values"] = build_unique_values(col_values, analysis["columns_fields"])
 
     # Perform testing on labels
     scores_table_labels = test_label(analysis["header"], formats, verbose=verbose)

--- a/csv_detective/output/utils.py
+++ b/csv_detective/output/utils.py
@@ -87,3 +87,21 @@ def extract_unique_from_multicat(values: pd.Series) -> list | None:
         return unique.tolist() if len(unique) <= MAX_NUMBER_CATEGORICAL_VALUES else None
     except Exception:
         return None
+
+
+def build_unique_values(
+    col_values: dict[str, pd.Series],
+    columns: dict[str, dict],
+) -> dict[str, list]:
+    """Build the unique_values map from per-column value counts (chunked detect or validate)."""
+    unique_values: dict[str, list] = {}
+    for col in col_values:
+        if columns[col]["format"] == "json" and all(
+            value.startswith("[") for value in col_values[col].index.dropna()
+        ):
+            unique = extract_unique_from_multicat(col_values[col].index.to_series())
+            if unique is not None:
+                unique_values[col] = unique
+        elif len(col_values[col]) <= MAX_NUMBER_CATEGORICAL_VALUES:
+            unique_values[col] = list(col_values[col].index.dropna())
+    return unique_values

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -244,7 +244,7 @@ def validate(
     analysis["unique_values"] = {}
     for col in col_values.keys():
         if previous_analysis["columns"][col]["format"] == "json" and all(
-            value.startswith("[") for value in col_values[col].index
+            value.startswith("[") for value in col_values[col].index.dropna()
         ):
             unique = extract_unique_from_multicat(col_values[col].index.to_series())
             if unique is not None:

--- a/csv_detective/validate.py
+++ b/csv_detective/validate.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from csv_detective.format import FormatsManager
-from csv_detective.output.utils import extract_unique_from_multicat
+from csv_detective.output.utils import build_unique_values
 from csv_detective.parsing.columns import (
     MAX_NUMBER_CATEGORICAL_VALUES,
     RATIO_CATEGORICAL_VALUES,
@@ -241,16 +241,7 @@ def validate(
         if len(values) <= MAX_NUMBER_CATEGORICAL_VALUES
         or (len(values) / sum(values)) <= RATIO_CATEGORICAL_VALUES
     ]
-    analysis["unique_values"] = {}
-    for col in col_values.keys():
-        if previous_analysis["columns"][col]["format"] == "json" and all(
-            value.startswith("[") for value in col_values[col].index.dropna()
-        ):
-            unique = extract_unique_from_multicat(col_values[col].index.to_series())
-            if unique is not None:
-                analysis["unique_values"][col] = unique
-        elif len(col_values[col]) <= MAX_NUMBER_CATEGORICAL_VALUES:
-            analysis["unique_values"][col] = list(col_values[col].index.dropna())
+    analysis["unique_values"] = build_unique_values(col_values, previous_analysis["columns"])
     return (
         True,
         analysis

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -10,6 +10,7 @@ from csv_detective import routine
 from csv_detective.output.profile import create_profile
 from csv_detective.parsing.csv import CHUNK_SIZE
 from csv_detective.utils import sanitize_for_json
+from csv_detective.validate import validate
 
 
 @pytest.fixture
@@ -651,6 +652,39 @@ def test_unique_values_json_with_missing_values(nb_rows):
         os.unlink(tmp_path)
     assert analysis["columns"]["json_col"]["python_type"] == "json"
     assert isinstance(analysis.get("unique_values"), dict)
+    assert analysis["unique_values"]["json_col"] == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize(
+    "nb_rows",
+    (CHUNK_SIZE // 10, CHUNK_SIZE + 1),
+)
+def test_validate_json_column_with_missing_values(nb_rows):
+    """JSON-format column with empty cells (NaN) must not crash validate."""
+    json_values = ['["a"]', '["b"]', '["c"]', ""]
+    csv_content = "json_col;id\n"
+    for k in range(nb_rows):
+        csv_content += f"{json_values[k % len(json_values)]};{k}\n"
+    with NamedTemporaryFile(
+        "w",
+        suffix=".csv",
+        delete=False,
+    ) as f:
+        f.write(csv_content)
+        tmp_path = f.name
+    try:
+        analysis = routine(
+            file_path=tmp_path,
+            num_rows=-1,
+            output_profile=False,
+            save_results=False,
+        )
+        is_valid, _, _ = validate(tmp_path, analysis)
+    finally:
+        import os
+
+        os.unlink(tmp_path)
+    assert is_valid
     assert analysis["unique_values"]["json_col"] == ["a", "b", "c"]
 
 


### PR DESCRIPTION
Following https://github.com/datagouv/csv-detective/pull/273:
Refactor to prevent code duplication between `detect_formats` and `validate`.